### PR TITLE
Implement Lock Save Functionality

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,23 +1,74 @@
 #![no_std]
 #![allow(non_snake_case)]
-use soroban_sdk::{contract, contractimpl};
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
 
 mod storage_types;
 pub use storage_types::*;
 
+mod lock;
+pub use lock::*;
+
 #[contract]
 pub struct NesteraContract;
 
-// This is a sample contract. Replace this placeholder with your own contract logic.
-// A corresponding test example is available in `test.rs`.
-//
-// For comprehensive examples, visit <https://github.com/stellar/soroban-examples>.
-// The repository includes use cases for the Stellar ecosystem, such as data storage on
-// the blockchain, token swaps, liquidity pools, and more.
-//
-// Refer to the official documentation:
-// <https://developers.stellar.org/docs/build/smart-contracts/overview>.
 #[contractimpl]
-impl NesteraContract {}
+impl NesteraContract {
+    /// Initialize a new user in the system
+    pub fn init_user(env: Env, user: Address) -> User {
+        user.require_auth();
+        
+        let user_data = User {
+            total_balance: 0,
+            savings_count: 0,
+        };
+        
+        let user_key = DataKey::User(user);
+        env.storage().persistent().set(&user_key, &user_data);
+        
+        user_data
+    }
+    
+    /// Create a new Lock Save plan
+    pub fn create_lock_save(
+        env: Env,
+        user: Address,
+        amount: i128,
+        duration: u64,
+    ) -> Result<u64, SavingsError> {
+        user.require_auth();
+        lock::create_lock_save(&env, user, amount, duration)
+    }
+    
+    /// Check if a Lock Save plan has matured
+    pub fn check_matured_lock(env: Env, lock_id: u64) -> bool {
+        lock::check_matured_lock(&env, lock_id)
+    }
+    
+    /// Withdraw from a matured Lock Save plan
+    pub fn withdraw_lock_save(
+        env: Env,
+        user: Address,
+        lock_id: u64,
+    ) -> Result<i128, SavingsError> {
+        user.require_auth();
+        lock::withdraw_lock_save(&env, user, lock_id)
+    }
+    
+    /// Get a Lock Save plan by ID
+    pub fn get_lock_save(env: Env, lock_id: u64) -> Option<LockSave> {
+        lock::get_lock_save(&env, lock_id)
+    }
+    
+    /// Get all Lock Save IDs for a user
+    pub fn get_user_lock_saves(env: Env, user: Address) -> Vec<u64> {
+        lock::get_user_lock_saves(&env, user)
+    }
+    
+    /// Get user information
+    pub fn get_user(env: Env, user: Address) -> Option<User> {
+        let user_key = DataKey::User(user);
+        env.storage().persistent().get(&user_key)
+    }
+}
 
 mod test;

--- a/contracts/src/lock.rs
+++ b/contracts/src/lock.rs
@@ -1,0 +1,173 @@
+use soroban_sdk::{Address, Env, Vec};
+use crate::{DataKey, LockSave, SavingsError, User};
+
+/// Creates a new Lock Save plan for a user
+/// 
+/// # Arguments
+/// * `env` - The contract environment
+/// * `user` - The address of the user creating the lock save
+/// * `amount` - The amount to lock (must be > 0)
+/// * `duration` - The lock duration in seconds (must be > 0)
+/// 
+/// # Returns
+/// * `Result<u64, SavingsError>` - The lock ID on success, or an error
+pub fn create_lock_save(
+    env: &Env,
+    user: Address,
+    amount: i128,
+    duration: u64,
+) -> Result<u64, SavingsError> {
+    // Validate inputs
+    if amount <= 0 {
+        return Err(SavingsError::InvalidAmount);
+    }
+    
+    if duration == 0 {
+        return Err(SavingsError::InvalidDuration);
+    }
+    
+    // Ensure user exists
+    let user_key = DataKey::User(user.clone());
+    if !env.storage().persistent().has(&user_key) {
+        return Err(SavingsError::UserNotFound);
+    }
+    
+    // Get next lock ID
+    let next_id_key = DataKey::NextLockId;
+    let lock_id: u64 = env.storage().persistent().get(&next_id_key).unwrap_or(1);
+    
+    // Update next lock ID
+    env.storage().persistent().set(&next_id_key, &(lock_id + 1));
+    
+    // Get current timestamp
+    let start_time = env.ledger().timestamp();
+    let maturity_time = start_time + duration;
+    
+    // Create LockSave struct
+    let lock_save = LockSave {
+        id: lock_id,
+        owner: user.clone(),
+        amount,
+        interest_rate: 800, // 8% APY for lock saves
+        start_time,
+        maturity_time,
+        is_withdrawn: false,
+    };
+    
+    // Store the LockSave
+    let lock_key = DataKey::LockSave(lock_id);
+    env.storage().persistent().set(&lock_key, &lock_save);
+    
+    // Add lock_id to user's lock saves list
+    let user_locks_key = DataKey::UserLockSaves(user.clone());
+    let mut user_locks: Vec<u64> = env.storage().persistent().get(&user_locks_key).unwrap_or(Vec::new(env));
+    user_locks.push_back(lock_id);
+    env.storage().persistent().set(&user_locks_key, &user_locks);
+    
+    // Update user's total balance and savings count
+    let mut user_data: User = env.storage().persistent().get(&user_key).unwrap();
+    user_data.total_balance += amount;
+    user_data.savings_count += 1;
+    env.storage().persistent().set(&user_key, &user_data);
+    
+    Ok(lock_id)
+}
+
+/// Checks if a Lock Save plan has matured
+/// 
+/// # Arguments
+/// * `env` - The contract environment
+/// * `lock_id` - The ID of the lock save to check
+/// 
+/// # Returns
+/// * `bool` - True if the lock has matured, false otherwise
+pub fn check_matured_lock(env: &Env, lock_id: u64) -> bool {
+    let lock_key = DataKey::LockSave(lock_id);
+    
+    if let Some(lock_save) = env.storage().persistent().get::<DataKey, LockSave>(&lock_key) {
+        let current_time = env.ledger().timestamp();
+        current_time >= lock_save.maturity_time
+    } else {
+        false
+    }
+}
+
+/// Withdraws from a matured Lock Save plan
+/// 
+/// # Arguments
+/// * `env` - The contract environment
+/// * `user` - The address of the user withdrawing
+/// * `lock_id` - The ID of the lock save to withdraw from
+/// 
+/// # Returns
+/// * `Result<i128, SavingsError>` - The withdrawn amount on success, or an error
+pub fn withdraw_lock_save(
+    env: &Env,
+    user: Address,
+    lock_id: u64,
+) -> Result<i128, SavingsError> {
+    let lock_key = DataKey::LockSave(lock_id);
+    
+    // Get the lock save
+    let mut lock_save: LockSave = env.storage().persistent()
+        .get(&lock_key)
+        .ok_or(SavingsError::LockNotFound)?;
+    
+    // Verify ownership
+    if lock_save.owner != user {
+        return Err(SavingsError::Unauthorized);
+    }
+    
+    // Check if already withdrawn
+    if lock_save.is_withdrawn {
+        return Err(SavingsError::AlreadyWithdrawn);
+    }
+    
+    // Check if matured
+    if !check_matured_lock(env, lock_id) {
+        return Err(SavingsError::LockNotMatured);
+    }
+    
+    // Calculate interest (simple interest for demonstration)
+    let duration_years = (lock_save.maturity_time - lock_save.start_time) as i128 / (365 * 24 * 60 * 60);
+    let interest = (lock_save.amount * lock_save.interest_rate as i128 * duration_years) / 10000;
+    let total_amount = lock_save.amount + interest;
+    
+    // Mark as withdrawn
+    lock_save.is_withdrawn = true;
+    env.storage().persistent().set(&lock_key, &lock_save);
+    
+    // Update user's total balance
+    let user_key = DataKey::User(user.clone());
+    let mut user_data: User = env.storage().persistent().get(&user_key).unwrap();
+    user_data.total_balance -= lock_save.amount; // Remove original amount from locked balance
+    env.storage().persistent().set(&user_key, &user_data);
+    
+    Ok(total_amount)
+}
+
+/// Gets a Lock Save plan by ID
+/// 
+/// # Arguments
+/// * `env` - The contract environment
+/// * `lock_id` - The ID of the lock save to retrieve
+/// 
+/// # Returns
+/// * `Option<LockSave>` - The lock save if found, None otherwise
+pub fn get_lock_save(env: &Env, lock_id: u64) -> Option<LockSave> {
+    let lock_key = DataKey::LockSave(lock_id);
+    env.storage().persistent().get(&lock_key)
+}
+
+/// Gets all Lock Save IDs for a user
+/// 
+/// # Arguments
+/// * `env` - The contract environment
+/// * `user` - The address of the user
+/// 
+/// # Returns
+/// * `Vec<u64>` - Vector of lock save IDs owned by the user
+pub fn get_user_lock_saves(env: &Env, user: Address) -> Vec<u64> {
+    let user_locks_key = DataKey::UserLockSaves(user);
+    env.storage().persistent().get(&user_locks_key).unwrap_or(Vec::new(env))
+}

--- a/contracts/src/storage_types.rs
+++ b/contracts/src/storage_types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Symbol};
+use soroban_sdk::{contracttype, contracterror, Address, Symbol};
 
 /// Represents the different types of savings plans available in Nestera
 #[contracttype]
@@ -33,6 +33,32 @@ pub struct User {
     pub savings_count: u32,
 }
 
+/// Represents a Lock Save plan with fixed duration
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LockSave {
+    pub id: u64,
+    pub owner: Address,
+    pub amount: i128,
+    pub interest_rate: u32,
+    pub start_time: u64,
+    pub maturity_time: u64,
+    pub is_withdrawn: bool,
+}
+
+/// Custom error types for the savings contract
+#[contracterror]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SavingsError {
+    InvalidAmount = 1,
+    InvalidDuration = 2,
+    UserNotFound = 3,
+    LockNotFound = 4,
+    LockNotMatured = 5,
+    AlreadyWithdrawn = 6,
+    Unauthorized = 7,
+}
+
 /// Storage keys for the contract's persistent data
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -41,4 +67,10 @@ pub enum DataKey {
     User(Address),
     /// Maps a (user address, plan_id) tuple to a SavingsPlan
     SavingsPlan(Address, u64),
+    /// Maps lock plan ID to LockSave struct
+    LockSave(u64),
+    /// Maps user to a list of their LockSave IDs
+    UserLockSaves(Address),
+    /// Stores the next auto-incrementing LockSave ID
+    NextLockId,
 }

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -1,8 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+use soroban_sdk::{symbol_short, testutils::{Address as _, Ledger as _}, Address, Env};
 
+// Existing tests for basic types
 #[test]
 fn test_user_instantiation() {
     let user = User {
@@ -290,4 +291,591 @@ fn test_plan_type_patterns() {
         assert_eq!(contrib, 1u32);
         assert_eq!(amount, 5_000_000);
     }
+}
+
+// New comprehensive Lock Save tests
+#[test]
+fn test_lock_save_struct() {
+    let env = Env::default();
+    let user = Address::generate(&env);
+    
+    let lock_save = LockSave {
+        id: 1,
+        owner: user.clone(),
+        amount: 1_000_000,
+        interest_rate: 800,
+        start_time: 1000000,
+        maturity_time: 1000000 + (30 * 24 * 60 * 60), // 30 days
+        is_withdrawn: false,
+    };
+    
+    assert_eq!(lock_save.id, 1);
+    assert_eq!(lock_save.owner, user);
+    assert_eq!(lock_save.amount, 1_000_000);
+    assert_eq!(lock_save.interest_rate, 800);
+    assert!(!lock_save.is_withdrawn);
+}
+
+#[test]
+fn test_create_lock_save_success() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user first
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    
+    // Create lock save
+    let result = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        30 * 24 * 60 * 60, // 30 days
+    );
+    
+    assert!(result.is_ok());
+    let lock_id = result.unwrap();
+    assert_eq!(lock_id, 1);
+    
+    // Verify lock save was created
+    let lock_save = NesteraContract::get_lock_save(env.clone(), lock_id);
+    assert!(lock_save.is_some());
+    
+    let lock = lock_save.unwrap();
+    assert_eq!(lock.id, lock_id);
+    assert_eq!(lock.owner, user);
+    assert_eq!(lock.amount, 1_000_000);
+    assert_eq!(lock.interest_rate, 800);
+    assert!(!lock.is_withdrawn);
+}
+
+#[test]
+fn test_create_lock_save_invalid_amount() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user first
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    
+    // Try to create lock save with invalid amount
+    let result = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        0, // Invalid amount
+        30 * 24 * 60 * 60,
+    );
+    
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SavingsError::InvalidAmount);
+}
+
+#[test]
+fn test_create_lock_save_invalid_duration() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user first
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    
+    // Try to create lock save with invalid duration
+    let result = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        0, // Invalid duration
+    );
+    
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SavingsError::InvalidDuration);
+}
+
+#[test]
+fn test_create_lock_save_user_not_found() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Try to create lock save without initializing user
+    let result = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        30 * 24 * 60 * 60,
+    );
+    
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SavingsError::UserNotFound);
+}
+
+#[test]
+fn test_check_matured_lock_not_matured() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user and create lock save
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        30 * 24 * 60 * 60, // 30 days
+    ).unwrap();
+    
+    // Check maturation (should not be matured yet)
+    let is_matured = NesteraContract::check_matured_lock(env.clone(), lock_id);
+    assert!(!is_matured);
+}
+
+#[test]
+fn test_check_matured_lock_matured() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user and create lock save with very short duration
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        1, // 1 second duration
+    ).unwrap();
+    
+    // Advance time
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 2; // Advance by 2 seconds
+    });
+    
+    // Check maturation (should be matured now)
+    let is_matured = NesteraContract::check_matured_lock(env.clone(), lock_id);
+    assert!(is_matured);
+}
+
+#[test]
+fn test_check_matured_lock_nonexistent() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    
+    // Check maturation for non-existent lock
+    let is_matured = NesteraContract::check_matured_lock(env.clone(), 999);
+    assert!(!is_matured);
+}
+
+#[test]
+fn test_multiple_lock_saves_unique_ids() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    
+    // Create multiple lock saves
+    let lock_id1 = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        30 * 24 * 60 * 60,
+    ).unwrap();
+    
+    let lock_id2 = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        2_000_000,
+        60 * 24 * 60 * 60,
+    ).unwrap();
+    
+    let lock_id3 = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        500_000,
+        15 * 24 * 60 * 60,
+    ).unwrap();
+    
+    // Verify unique IDs
+    assert_eq!(lock_id1, 1);
+    assert_eq!(lock_id2, 2);
+    assert_eq!(lock_id3, 3);
+    
+    // Verify all locks exist and have correct amounts
+    let lock1 = NesteraContract::get_lock_save(env.clone(), lock_id1).unwrap();
+    let lock2 = NesteraContract::get_lock_save(env.clone(), lock_id2).unwrap();
+    let lock3 = NesteraContract::get_lock_save(env.clone(), lock_id3).unwrap();
+    
+    assert_eq!(lock1.amount, 1_000_000);
+    assert_eq!(lock2.amount, 2_000_000);
+    assert_eq!(lock3.amount, 500_000);
+}
+
+#[test]
+fn test_user_lock_saves_tracking() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    
+    // Create multiple lock saves
+    let lock_id1 = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        30 * 24 * 60 * 60,
+    ).unwrap();
+    
+    let lock_id2 = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        2_000_000,
+        60 * 24 * 60 * 60,
+    ).unwrap();
+    
+    // Get user's lock saves
+    let user_locks = NesteraContract::get_user_lock_saves(env.clone(), user.clone());
+    
+    assert_eq!(user_locks.len(), 2);
+    assert!(user_locks.contains(&lock_id1));
+    assert!(user_locks.contains(&lock_id2));
+}
+
+#[test]
+fn test_user_balance_update_on_lock_creation() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    
+    // Create lock save
+    let _lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        30 * 24 * 60 * 60,
+    ).unwrap();
+    
+    // Check user's updated balance and savings count
+    let updated_user = NesteraContract::get_user(env.clone(), user.clone()).unwrap();
+    assert_eq!(updated_user.total_balance, 1_000_000);
+    assert_eq!(updated_user.savings_count, 1);
+}
+
+#[test]
+fn test_lock_save_start_and_maturity_times() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    
+    let duration = 30 * 24 * 60 * 60; // 30 days
+    let start_time = env.ledger().timestamp();
+    
+    // Create lock save
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        duration,
+    ).unwrap();
+    
+    // Verify times
+    let lock_save = NesteraContract::get_lock_save(env.clone(), lock_id).unwrap();
+    assert_eq!(lock_save.start_time, start_time);
+    assert_eq!(lock_save.maturity_time, start_time + duration);
+}
+
+#[test]
+fn test_withdraw_lock_save_success() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user and create lock save with short duration
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        1, // 1 second duration
+    ).unwrap();
+    
+    // Advance time to mature the lock
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 2;
+    });
+    
+    // Withdraw from lock save
+    let result = NesteraContract::withdraw_lock_save(env.clone(), user.clone(), lock_id);
+    assert!(result.is_ok());
+    
+    // Verify lock is marked as withdrawn
+    let lock_save = NesteraContract::get_lock_save(env.clone(), lock_id).unwrap();
+    assert!(lock_save.is_withdrawn);
+}
+
+#[test]
+fn test_withdraw_lock_save_not_matured() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user and create lock save
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        30 * 24 * 60 * 60, // 30 days
+    ).unwrap();
+    
+    // Try to withdraw before maturation
+    let result = NesteraContract::withdraw_lock_save(env.clone(), user.clone(), lock_id);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SavingsError::LockNotMatured);
+}
+
+#[test]
+fn test_withdraw_lock_save_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user1 and create lock save
+    let _user_data = NesteraContract::init_user(env.clone(), user1.clone());
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user1.clone(),
+        1_000_000,
+        1, // 1 second duration
+    ).unwrap();
+    
+    // Advance time to mature the lock
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 2;
+    });
+    
+    // Try to withdraw with different user
+    let result = NesteraContract::withdraw_lock_save(env.clone(), user2.clone(), lock_id);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SavingsError::Unauthorized);
+}
+
+#[test]
+fn test_withdraw_lock_save_already_withdrawn() {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Initialize user and create lock save with short duration
+    let _user_data = NesteraContract::init_user(env.clone(), user.clone());
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000_000,
+        1, // 1 second duration
+    ).unwrap();
+    
+    // Advance time to mature the lock
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 2;
+    });
+    
+    // First withdrawal should succeed
+    let result1 = NesteraContract::withdraw_lock_save(env.clone(), user.clone(), lock_id);
+    assert!(result1.is_ok());
+    
+    // Second withdrawal should fail
+    let result2 = NesteraContract::withdraw_lock_save(env.clone(), user.clone(), lock_id);
+    assert!(result2.is_err());
+    assert_eq!(result2.unwrap_err(), SavingsError::AlreadyWithdrawn);
+}
+
+#[test]
+fn test_get_user_before_after_init() {
+    let env = Env::default();
+    let _contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+
+    // Before init_user, get_user should return None
+    let before = NesteraContract::get_user(env.clone(), user.clone());
+    assert!(before.is_none());
+
+    // After init_user, get_user should return default user struct
+    let created = NesteraContract::init_user(env.clone(), user.clone());
+    assert_eq!(created.total_balance, 0);
+    assert_eq!(created.savings_count, 0);
+
+    let after = NesteraContract::get_user(env.clone(), user.clone());
+    assert!(after.is_some());
+    let fetched = after.unwrap();
+    assert_eq!(fetched.total_balance, 0);
+    assert_eq!(fetched.savings_count, 0);
+}
+
+#[test]
+fn test_withdraw_returns_amount_with_interest() {
+    let env = Env::default();
+    let _contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    // Initialize user
+    let _ = NesteraContract::init_user(env.clone(), user.clone());
+
+    // Use exactly one year duration to get 1x interest period
+    let one_year_secs: u64 = 365 * 24 * 60 * 60;
+    let principal: i128 = 1_000_000;
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        principal,
+        one_year_secs,
+    )
+    .unwrap();
+
+    // Advance time to at least maturity
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + one_year_secs + 1;
+    });
+
+    // Withdraw and validate amount = principal + interest(8% of principal)
+    let result = NesteraContract::withdraw_lock_save(env.clone(), user.clone(), lock_id);
+    assert!(result.is_ok());
+    let withdrawn = result.unwrap();
+
+    let expected_interest: i128 = principal * 800 / 10_000; // 8.00% in bps
+    let expected_total: i128 = principal + expected_interest;
+    assert_eq!(withdrawn, expected_total);
+}
+
+#[test]
+fn test_next_lock_id_increments_across_users() {
+    let env = Env::default();
+    let _contract_id = env.register(NesteraContract, ());
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    // Init both users
+    let _ = NesteraContract::init_user(env.clone(), user1.clone());
+    let _ = NesteraContract::init_user(env.clone(), user2.clone());
+
+    // Create locks for each user and assert global incrementing IDs
+    let id1 = NesteraContract::create_lock_save(
+        env.clone(),
+        user1.clone(),
+        100,
+        10,
+    )
+    .unwrap();
+    let id2 = NesteraContract::create_lock_save(
+        env.clone(),
+        user2.clone(),
+        200,
+        20,
+    )
+    .unwrap();
+
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn test_user_lock_ids_persist_after_withdraw() {
+    let env = Env::default();
+    let _contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    let _ = NesteraContract::init_user(env.clone(), user.clone());
+
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        1_000,
+        1,
+    )
+    .unwrap();
+
+    // Mature
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 2;
+    });
+
+    // Withdraw
+    let _ = NesteraContract::withdraw_lock_save(env.clone(), user.clone(), lock_id).unwrap();
+
+    // Ensure user's lock IDs still contain the withdrawn lock (we don't remove IDs on withdraw)
+    let ids = NesteraContract::get_user_lock_saves(env.clone(), user.clone());
+    assert!(ids.contains(&lock_id));
+}
+
+#[test]
+fn test_check_matured_lock_boundary_condition() {
+    let env = Env::default();
+    let _contract_id = env.register(NesteraContract, ());
+    let user = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    let _ = NesteraContract::init_user(env.clone(), user.clone());
+
+    // Create a lock and fetch its recorded times
+    let duration: u64 = 10;
+    let lock_id = NesteraContract::create_lock_save(
+        env.clone(),
+        user.clone(),
+        5_000,
+        duration,
+    )
+    .unwrap();
+
+    let lock = NesteraContract::get_lock_save(env.clone(), lock_id).unwrap();
+
+    // Jump to exactly maturity_time; should be considered matured (>=)
+    env.ledger().with_mut(|li| {
+        li.timestamp = lock.maturity_time;
+    });
+
+    let matured = NesteraContract::check_matured_lock(env.clone(), lock_id);
+    assert!(matured);
 }

--- a/contracts/test_snapshots/test/test_check_matured_lock_boundary_condition.1.json
+++ b/contracts/test_snapshots/test/test_check_matured_lock_boundary_condition.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_check_matured_lock_matured.1.json
+++ b/contracts/test_snapshots/test/test_check_matured_lock_matured.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_check_matured_lock_nonexistent.1.json
+++ b/contracts/test_snapshots/test/test_check_matured_lock_nonexistent.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_check_matured_lock_not_matured.1.json
+++ b/contracts/test_snapshots/test/test_check_matured_lock_not_matured.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_create_lock_save_invalid_amount.1.json
+++ b/contracts/test_snapshots/test/test_create_lock_save_invalid_amount.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_create_lock_save_invalid_duration.1.json
+++ b/contracts/test_snapshots/test/test_create_lock_save_invalid_duration.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_create_lock_save_success.1.json
+++ b/contracts/test_snapshots/test/test_create_lock_save_success.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_create_lock_save_user_not_found.1.json
+++ b/contracts/test_snapshots/test/test_create_lock_save_user_not_found.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_get_user_before_after_init.1.json
+++ b/contracts/test_snapshots/test/test_get_user_before_after_init.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_lock_save_start_and_maturity_times.1.json
+++ b/contracts/test_snapshots/test/test_lock_save_start_and_maturity_times.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_multiple_lock_saves_unique_ids.1.json
+++ b/contracts/test_snapshots/test/test_multiple_lock_saves_unique_ids.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_next_lock_id_increments_across_users.1.json
+++ b/contracts/test_snapshots/test/test_next_lock_id_increments_across_users.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_user_balance_update_on_lock_creation.1.json
+++ b/contracts/test_snapshots/test/test_user_balance_update_on_lock_creation.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_user_lock_ids_persist_after_withdraw.1.json
+++ b/contracts/test_snapshots/test/test_user_lock_ids_persist_after_withdraw.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_user_lock_saves_tracking.1.json
+++ b/contracts/test_snapshots/test/test_user_lock_saves_tracking.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_withdraw_lock_save_already_withdrawn.1.json
+++ b/contracts/test_snapshots/test/test_withdraw_lock_save_already_withdrawn.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_withdraw_lock_save_not_matured.1.json
+++ b/contracts/test_snapshots/test/test_withdraw_lock_save_not_matured.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_withdraw_lock_save_success.1.json
+++ b/contracts/test_snapshots/test/test_withdraw_lock_save_success.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_withdraw_lock_save_unauthorized.1.json
+++ b/contracts/test_snapshots/test/test_withdraw_lock_save_unauthorized.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/test/test_withdraw_returns_amount_with_interest.1.json
+++ b/contracts/test_snapshots/test/test_withdraw_returns_amount_with_interest.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION

Summary

This PR implements the core Lock Save functionality, enabling users to lock funds for a fixed duration and withdraw only after the lock period has matured. It introduces on-chain storage, unique lock tracking, and maturity validation logic, along with unit tests.

Key Changes

Added Lock Save storage and data structures

LockSave(u64) → maps lock plan ID to LockSave struct

UserLockSaves(Address) → maps user address to their lock save IDs

NextLockId → auto-incrementing ID counter

Defined LockSave struct with #[contracttype]:

id, owner, amount, interest_rate

start_time, maturity_time

is_withdrawn

Implemented create_lock_save:

Validates amount and duration

Assigns unique lock IDs

Sets start and maturity timestamps using ledger time

Persists lock plans and user mappings in storage

Implemented check_matured_lock:

Returns true when the current timestamp is greater than or equal to the lock’s maturity time

Added unit tests to verify:

Successful creation of Lock Save plans

Correct start and maturity time calculation

Accurate maturity checks

Acceptance Criteria Met

✅ Lock Save plans are stored correctly on-chain

✅ Auto-generated LockSave IDs are unique

✅ Lock maturity is correctly calculated

✅ Unit tests cover creation and maturity logic

✅ Contract builds successfully with make build closes #9 