### PR TITLE
feat:add emergency pause/unpause with admin

### DIFF
--- a/contracts/src/admin_tests.rs
+++ b/contracts/src/admin_tests.rs
@@ -1,1 +1,150 @@
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, Error, InvokeError, Symbol};
+
+use crate::{NesteraContract, NesteraContractClient, SavingsError};
+
+fn setup() -> (Env, NesteraContractClient<'static>, Address) {
+	let env = Env::default();
+	let contract_id = env.register(NesteraContract, ());
+	let client = NesteraContractClient::new(&env, &contract_id);
+	let admin = Address::generate(&env);
+	let admin_pk = BytesN::from_array(&env, &[1u8; 32]);
+
+	env.mock_all_auths();
+	client.initialize(&admin, &admin_pk);
+
+	(env, client, admin)
+}
+
+fn assert_contract_error(err: Result<Error, InvokeError>, expected: SavingsError) {
+	assert_eq!(err, Ok(Error::from_contract_error(expected as u32)));
+}
+
+fn assert_savings_error(err: Result<SavingsError, InvokeError>, expected: SavingsError) {
+	assert_eq!(err, Ok(expected));
+}
+
+#[test]
+fn non_admin_cannot_pause_or_unpause() {
+	let (env, client, _admin) = setup();
+	let non_admin = Address::generate(&env);
+
+	env.mock_all_auths();
+	assert_savings_error(
+		client.try_pause(&non_admin).unwrap_err(),
+		SavingsError::Unauthorized,
+	);
+	assert_savings_error(
+		client.try_unpause(&non_admin).unwrap_err(),
+		SavingsError::Unauthorized,
+	);
+}
+
+#[test]
+fn paused_blocks_write_paths() {
+	let (env, client, admin) = setup();
+	let user = Address::generate(&env);
+
+	env.mock_all_auths();
+	assert!(client.try_pause(&admin).is_ok());
+
+	assert_savings_error(
+		client.try_initialize_user(&user).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_contract_error(
+		client.try_init_user(&user).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_contract_error(
+		client
+			.try_create_savings_plan(&user, &crate::storage_types::PlanType::Flexi, &100)
+			.unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_savings_error(
+		client.try_deposit_flexi(&user, &10).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+	assert_savings_error(
+		client.try_withdraw_flexi(&user, &5).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_contract_error(
+		client.try_create_lock_save(&user, &100, &30).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_contract_error(
+		client.try_withdraw_lock_save(&user, &1).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	let goal_name = Symbol::new(&env, "goal");
+	assert_contract_error(
+		client
+			.try_create_goal_save(&user, &goal_name, &1000, &100)
+			.unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_contract_error(
+		client.try_deposit_to_goal_save(&user, &1, &50).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_contract_error(
+		client
+			.try_withdraw_completed_goal_save(&user, &1)
+			.unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_contract_error(
+		client.try_break_goal_save(&user, &1).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_savings_error(
+		client
+			.try_create_group_save(
+				&user,
+				&soroban_sdk::String::from_str(&env, "title"),
+				&soroban_sdk::String::from_str(&env, "desc"),
+				&soroban_sdk::String::from_str(&env, "cat"),
+				&1000,
+				&0,
+				&10,
+				&true,
+				&1,
+				&2,
+			)
+			.unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+
+	assert_savings_error(
+		client.try_join_group_save(&user, &1).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+	assert_savings_error(
+		client.try_contribute_to_group_save(&user, &1, &10).unwrap_err(),
+		SavingsError::ContractPaused,
+	);
+}
+
+#[test]
+fn unpause_restores_write_paths() {
+	let (env, client, admin) = setup();
+	let user = Address::generate(&env);
+
+	env.mock_all_auths();
+	assert!(client.try_pause(&admin).is_ok());
+	assert!(client.try_unpause(&admin).is_ok());
+
+	assert!(client.try_initialize_user(&user).is_ok());
+}
 

--- a/contracts/src/flexi.rs
+++ b/contracts/src/flexi.rs
@@ -1,10 +1,13 @@
 // New/Correct
+use crate::ensure_not_paused;
 use crate::errors::SavingsError;
 use crate::storage_types::{DataKey, User};
 use soroban_sdk::{Address, Env};
 
 /// Handles depositing funds into the Flexi Save pool.
 pub fn flexi_deposit(env: Env, user: Address, amount: i128) -> Result<(), SavingsError> {
+    ensure_not_paused(&env)?;
+
     // 1. Verify the caller is the user
     user.require_auth();
 
@@ -39,6 +42,8 @@ pub fn flexi_deposit(env: Env, user: Address, amount: i128) -> Result<(), Saving
 
 /// Handles withdrawing funds from the Flexi Save pool.
 pub fn flexi_withdraw(env: Env, user: Address, amount: i128) -> Result<(), SavingsError> {
+    ensure_not_paused(&env)?;
+
     // 1. Verify the caller is the user
     user.require_auth();
 

--- a/contracts/src/goal.rs
+++ b/contracts/src/goal.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{Address, Env, Vec};
 
+use crate::ensure_not_paused;
 use crate::errors::SavingsError;
 use crate::storage_types::{DataKey, GoalSave, User};
 use crate::users;
@@ -11,6 +12,7 @@ pub fn create_goal_save(
     target_amount: i128,
     initial_deposit: i128,
 ) -> Result<u64, SavingsError> {
+    ensure_not_paused(env)?;
     user.require_auth();
 
     if target_amount <= 0 {
@@ -56,6 +58,7 @@ pub fn deposit_to_goal_save(
     goal_id: u64,
     amount: i128,
 ) -> Result<(), SavingsError> {
+    ensure_not_paused(env)?;
     user.require_auth();
 
     if amount <= 0 {
@@ -93,6 +96,7 @@ pub fn withdraw_completed_goal_save(
     user: Address,
     goal_id: u64,
 ) -> Result<i128, SavingsError> {
+    ensure_not_paused(env)?;
     user.require_auth();
 
     if !users::user_exists(env, &user) {
@@ -132,6 +136,7 @@ pub fn withdraw_completed_goal_save(
 }
 
 pub fn break_goal_save(env: &Env, user: Address, goal_id: u64) -> Result<(), SavingsError> {
+    ensure_not_paused(env)?;
     user.require_auth();
 
     if !users::user_exists(env, &user) {

--- a/contracts/src/group.rs
+++ b/contracts/src/group.rs
@@ -1,5 +1,6 @@
 use crate::errors::SavingsError;
 use crate::storage_types::{DataKey, GroupSave};
+use crate::ensure_not_paused;
 use crate::users;
 use soroban_sdk::{Address, Env, String, Vec};
 
@@ -42,6 +43,7 @@ pub fn create_group_save(
     start_time: u64,
     end_time: u64,
 ) -> Result<u64, SavingsError> {
+    ensure_not_paused(env)?;
     // Validate target_amount > 0
     if target_amount <= 0 {
         return Err(SavingsError::InvalidAmount);
@@ -225,6 +227,7 @@ fn add_group_to_user_list(env: &Env, user: &Address, group_id: u64) -> Result<()
 /// - Group is not public
 /// - User is already a member
 pub fn join_group_save(env: &Env, user: Address, group_id: u64) -> Result<(), SavingsError> {
+    ensure_not_paused(env)?;
     // Ensure user exists
     if !users::user_exists(env, &user) {
         return Err(SavingsError::UserNotFound);
@@ -324,6 +327,7 @@ pub fn contribute_to_group_save(
     group_id: u64,
     amount: i128,
 ) -> Result<(), SavingsError> {
+    ensure_not_paused(env)?;
     // Validate amount > 0
     if amount <= 0 {
         return Err(SavingsError::InvalidAmount);

--- a/contracts/src/lock.rs
+++ b/contracts/src/lock.rs
@@ -1,5 +1,6 @@
 use crate::errors::SavingsError;
 use crate::storage_types::{DataKey, LockSave, User};
+use crate::ensure_not_paused;
 use crate::users;
 use soroban_sdk::{symbol_short, Address, Env, Vec};
 
@@ -10,17 +11,8 @@ pub fn create_lock_save(
     amount: i128,
     duration: u64,
 ) -> Result<u64, SavingsError> {
+    ensure_not_paused(env)?;
     user.require_auth();
-
-    // Check if contract is paused
-    let is_paused: bool = env
-        .storage()
-        .persistent()
-        .get(&DataKey::Paused)
-        .unwrap_or(false);
-    if is_paused {
-        return Err(SavingsError::ContractPaused);
-    }
 
     // Validate inputs
     if amount <= 0 {
@@ -74,16 +66,8 @@ pub fn create_lock_save(
 }
 
 pub fn withdraw_lock_save(env: &Env, user: Address, lock_id: u64) -> Result<i128, SavingsError> {
+    ensure_not_paused(env)?;
     user.require_auth();
-
-    let is_paused: bool = env
-        .storage()
-        .persistent()
-        .get(&DataKey::Paused)
-        .unwrap_or(false);
-    if is_paused {
-        return Err(SavingsError::ContractPaused);
-    }
 
     let mut lock_save = get_lock_save(env, lock_id).ok_or(SavingsError::PlanNotFound)?;
 

--- a/contracts/src/storage_types.rs
+++ b/contracts/src/storage_types.rs
@@ -88,6 +88,7 @@ pub enum SavingsError {
     AlreadyWithdrawn = 6,
     Unauthorized = 7,
 }
+
 /// Represents a Goal Save plan with target amount
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/src/users.rs
+++ b/contracts/src/users.rs
@@ -2,6 +2,7 @@ use soroban_sdk::{Address, Env};
 
 use crate::errors::SavingsError;
 use crate::storage_types::{DataKey, User};
+use crate::ensure_not_paused;
 
 /// Check if a user exists in storage
 ///
@@ -47,6 +48,7 @@ pub fn get_user(env: &Env, user: &Address) -> Result<User, SavingsError> {
 /// # Authorization
 /// Requires authorization from the user being initialized
 pub fn initialize_user(env: &Env, user: Address) -> Result<(), SavingsError> {
+    ensure_not_paused(env)?;
     // Require authorization from the user being initialized
     user.require_auth();
 

--- a/contracts/test_snapshots/admin_tests/non_admin_cannot_pause_or_unpause.1.json
+++ b/contracts/test_snapshots/admin_tests/non_admin_cannot_pause_or_unpause.1.json
@@ -1,0 +1,209 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Paused"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Paused"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bool": false
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminPublicKey"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/admin_tests/paused_blocks_write_paths.1.json
+++ b/contracts/test_snapshots/admin_tests/paused_blocks_write_paths.1.json
@@ -1,0 +1,273 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Paused"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Paused"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bool": true
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminPublicKey"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/admin_tests/unpause_restores_write_paths.1.json
+++ b/contracts/test_snapshots/admin_tests/unpause_restores_write_paths.1.json
@@ -1,0 +1,425 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "unpause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize_user",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Paused"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Paused"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bool": false
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "User"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "User"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "savings_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminPublicKey"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
# Emergency pause/unpause with admin #54 
Add an admin‑only emergency pause/unpause mechanism and ensure all state‑mutating contract entrypoints respect the paused state.

## Summary of Changes
This PR updates the contract storage and logic to include an administrative layer. It introduces a global pause state that guards every critical "write" path—from user initialization to savings plan withdrawals. While the system is paused, users can still view their data (read-only), but cannot commit new transactions until the administrator restores functionality.

## Core Implementation

- State Management: Added DataKey::Paused and DataKey::Admin to the storage schema.
- Initialization: Updated the initialize function to set the Admin address and default the Paused state to false
- Access Control: Implemented ensure_not_paused() helper to streamline guard checks across the codebase 

##  Administrative Entrypoints

- New authenticated endpoints were added 
- pause / unpause: Restricts access to the stored Admin only. Includes storage toggles and event emission for off-chain monitoring.