### PR TITLE
Feat/why trust nestera

### DIFF
--- a/frontend/app/LandingPage/LandingPage.tsx
+++ b/frontend/app/LandingPage/LandingPage.tsx
@@ -20,8 +20,8 @@ const LandingPage: React.FC = () => {
         stat={{ label: "Annual Yield", value: "12% APY" }}
       />
 
-      <HowItWorks />
       <WhyTrust />
+      <HowItWorks />
       <SavingsProducts />
       <FAQ />
       <Newsletter />

--- a/frontend/app/components/WhyTrust.tsx
+++ b/frontend/app/components/WhyTrust.tsx
@@ -18,9 +18,9 @@ const trustItems = [
       "Pennies per transaction, thanks to Soroban's efficiency.",
   },
   {
-    title: 'Fast Finality',
+    title: 'No Penalty',
     description:
-      'Settlement in seconds, not days. Access your funds when you need them.',
+      'No penalties or surprise charges; transparent contracts keep terms clear.',
   },
 ];
 


### PR DESCRIPTION
Closes #93

Implements the "Why Trust Nestera?" trust-building section as per the approved design.

- Created `frontend/app/components/WhyTrust.tsx`
- Added 4 trust items with teal checkmark icons, bold titles, and descriptions
- Integrated the section into the landing page at `frontend/app/LandingPage/LandingPage.tsx`
- Updated trust copy to match issue requirements:
  - Transparent
  - Non-custodial
  - Low Fees
  - No Penalty
