### PR TITLE
feat: add Dashboard nav link and fix mobile layout responsiveness

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -17,6 +17,7 @@ const Navbar: React.FC = () => {
   const navLinks: NavLink[] = [
     { label: "Features", href: "/features" },
     { label: "Savings", href: "/savings" },
+    { label: "Dashboard", href: "/dashboard" },
     { label: "Community", href: "/community" },
     { label: "Docs", href: "/docs" },
   ];

--- a/frontend/app/components/dashboard/Sidebar.tsx
+++ b/frontend/app/components/dashboard/Sidebar.tsx
@@ -150,11 +150,12 @@ const Sidebar: React.FC = () => {
 
       {/* Mobile hamburger */}
       <button
-        className="md:hidden fixed top-4 left-4 z-[60] bg-transparent border-0 text-[#d6f6f6] cursor-pointer"
+        className="md:hidden fixed top-5 left-4 z-[60] flex items-center justify-center bg-[#0e2330] border border-white/8 rounded-xl text-[#6a9fae] hover:text-white transition-colors cursor-pointer"
+        style={{ width: 38, height: 38 }}
         onClick={() => setOpen(!open)}
         aria-label="Toggle menu"
       >
-        {open ? <X size={20} /> : <Menu size={20} />}
+        {open ? <X size={18} /> : <Menu size={18} />}
       </button>
     </>
   );

--- a/frontend/app/components/dashboard/TopNav.tsx
+++ b/frontend/app/components/dashboard/TopNav.tsx
@@ -6,8 +6,8 @@ import { Search, Bell, HelpCircle } from "lucide-react";
 const TopNav: React.FC = () => {
   return (
     <header
-      className="sticky top-0 right-0 flex items-center justify-between bg-transparent z-40 backdrop-blur-sm"
-      style={{ height: 64, padding: "0 24px" }}
+      className="sticky top-0 right-0 flex items-center justify-between bg-transparent z-40 backdrop-blur-sm px-0 md:px-6"
+      style={{ height: 64 }}
     >
       {/* Left: heading + subtitle */}
       <div className="hidden sm:flex flex-col gap-0.5">
@@ -23,7 +23,7 @@ const TopNav: React.FC = () => {
       </div>
 
       {/* Right: icons + avatar */}
-      <div className="flex items-center" style={{ gap: 10 }}>
+      <div className="flex items-center ml-auto" style={{ gap: 10 }}>
         {[
           { Icon: Search, label: "Search" },
           { Icon: Bell, label: "Notifications" },

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -12,11 +12,11 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="block bg-[#061218] min-h-screen">
+    <div className="block bg-[#061218] min-h-screen overflow-x-hidden">
       <Sidebar />
 
-      {/* 260px left margin to clear the fixed sidebar on all screens */}
-      <div style={{ marginLeft: 180 }} className="min-h-screen px-6 py-5">
+      {/* Responsive margin: no margin on mobile, 180px on md+ to clear the fixed sidebar */}
+      <div className="min-h-screen px-4 py-5 md:ml-[180px] md:px-6 max-w-full">
         <TopNav />
         <div className="mt-2">{children}</div>
       </div>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -6,23 +6,23 @@ import RecentTransactionsWidget from "../components/dashboard/RecentTransactions
 
 export default function DashboardPage() {
   return (
-    <div className="w-full">
+    <div className="w-full max-w-full overflow-x-hidden">
       {/* Top row: NetWorth (stretches) + QuickActions (fixed width) */}
-      <div className="flex gap-[18px] items-start flex-col md:flex-row">
-        <div className="flex-1 w-full">
+      <div className="flex gap-4 md:gap-[18px] items-start flex-col md:flex-row">
+        <div className="flex-1 w-full min-w-0">
           <NetWorthCard />
         </div>
-        <div className="w-full md:w-[360px] md:max-w-[40%]">
+        <div className="w-full md:w-[360px] md:max-w-[40%] min-w-0">
           <QuickActionsGrid />
         </div>
       </div>
 
       {/* Second row: ActivePoolList + RecentTransactions */}
-      <div className="mt-5 flex gap-5">
-        <div className="flex-1 max-w-[760px]">
+      <div className="mt-4 md:mt-5 flex gap-4 md:gap-5 flex-col lg:flex-row">
+        <div className="flex-1 w-full min-w-0">
           <ActivePoolList />
         </div>
-        <div className="w-[320px] hidden lg:block">
+        <div className="flex-1 w-full min-w-0">
           <RecentTransactionsWidget />
         </div>
       </div>


### PR DESCRIPTION
This PR closes #214 

https://github.com/user-attachments/assets/897c901a-cd3d-4d6c-b682-908da9316ada

## Summary
Adds Dashboard navigation link to the home navbar and fixes mobile layout issues in the dashboard.

## Changes
- **Navbar**: Added "Dashboard" link between Savings and Community
- **Dashboard Layout**: 
  - Fixed black space on mobile by making sidebar margin responsive
  - Added overflow-x-hidden to prevent horizontal scrolling
  - Adjusted padding for mobile (px-4) vs desktop (px-6)
- **Recent Transactions Widget**: 
  - Changed from fixed 320px width to full-width responsive layout
  - Now visible on all screen sizes (previously hidden on mobile)
  - Shares equal space with Active Pools on large screens
- **Hamburger Menu**: Styled to match design system with proper background, border, and hover states
- **Responsive Improvements**: Added min-w-0 to flex children and responsive gaps throughout

## Testing
Verified layout works correctly on:
- ✅ Mobile (no black space, proper hamburger styling)
- ✅ Tablet (smooth transition between layouts)
- ✅ Desktop (sidebar visible, proper spacing)