### PR TITLE
feat: Query Contract Execution

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { ClaimsModule } from './modules/claims/claims.module';
 import { DisputesModule } from './modules/disputes/disputes.module';
 import { AdminAnalyticsModule } from './modules/admin-analytics/admin-analytics.module';
 import { SavingsModule } from './modules/savings/savings.module';
+import { GovernanceModule } from './modules/governance/governance.module';
 import { TestRbacModule } from './test-rbac/test-rbac.module';
 import { TestThrottlingModule } from './test-throttling/test-throttling.module';
 import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard';
@@ -82,6 +83,7 @@ import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard';
     DisputesModule,
     AdminAnalyticsModule,
     SavingsModule,
+    GovernanceModule,
     TestRbacModule,
     TestThrottlingModule,
     ThrottlerModule.forRoot([

--- a/backend/src/modules/blockchain/stellar.service.spec.ts
+++ b/backend/src/modules/blockchain/stellar.service.spec.ts
@@ -1,8 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { Keypair, nativeToScVal } from '@stellar/stellar-sdk';
 import { StellarService } from './stellar.service';
 import { TransactionDto } from './dto/transaction.dto';
 import { RpcClientWrapper } from './rpc-client.wrapper';
+
+const TEST_PUBLIC_KEY = Keypair.random().publicKey();
+const TEST_DELEGATE_KEY = Keypair.random().publicKey();
 
 /** Build a minimal fake Horizon transaction record */
 const makeFakeTx = (overrides: Partial<Record<string, unknown>> = {}) => ({
@@ -20,7 +24,7 @@ const makeFakeTx = (overrides: Partial<Record<string, unknown>> = {}) => ({
   ...overrides,
 });
 
-describe('StellarService – getRecentTransactions', () => {
+describe('StellarService', () => {
   let service: StellarService;
   let mockTransactionCall: jest.Mock;
   let mockRpcClient: jest.Mocked<RpcClientWrapper>;
@@ -39,6 +43,8 @@ describe('StellarService – getRecentTransactions', () => {
                 'stellar.rpcUrl': 'https://soroban-testnet.stellar.org',
                 'stellar.horizonUrl': 'https://horizon-testnet.stellar.org',
                 'stellar.network': 'testnet',
+                'stellar.contractId':
+                  'CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5',
                 'stellar.rpcFallbackUrls': [],
                 'stellar.horizonFallbackUrls': [],
                 'stellar.rpcMaxRetries': 3,
@@ -82,7 +88,7 @@ describe('StellarService – getRecentTransactions', () => {
     mockTransactionCall.mockResolvedValue({ records: [fakeTx] });
 
     const result = await service.getRecentTransactions(
-      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      TEST_PUBLIC_KEY,
     );
 
     expect(result).toHaveLength(1);
@@ -110,7 +116,7 @@ describe('StellarService – getRecentTransactions', () => {
     mockTransactionCall.mockResolvedValue({ records: [fakeTx] });
 
     const [tx] = await service.getRecentTransactions(
-      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      TEST_PUBLIC_KEY,
     );
 
     expect(tx.token).toBe('USDC');
@@ -124,7 +130,7 @@ describe('StellarService – getRecentTransactions', () => {
       .mockImplementation(() => {});
 
     const result = await service.getRecentTransactions(
-      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      TEST_PUBLIC_KEY,
     );
 
     expect(result).toEqual([]);
@@ -138,7 +144,7 @@ describe('StellarService – getRecentTransactions', () => {
     mockTransactionCall.mockResolvedValue({ records: [fakeTx] });
 
     const [tx] = await service.getRecentTransactions(
-      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      TEST_PUBLIC_KEY,
     );
 
     expect(tx.amount).toBe('0');
@@ -150,7 +156,7 @@ describe('StellarService – getRecentTransactions', () => {
     mockTransactionCall.mockResolvedValue({ records: [] });
 
     await service.getRecentTransactions(
-      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      TEST_PUBLIC_KEY,
       5,
     );
 
@@ -159,5 +165,54 @@ describe('StellarService – getRecentTransactions', () => {
       expect.any(Function),
       'horizon',
     );
+  });
+
+  it('should return a delegated wallet when contract data resolves to an address', async () => {
+    jest
+      .spyOn(mockRpcClient, 'executeWithRetry')
+      .mockImplementation(async (operation) => {
+        const fakeRpcServer = {
+          getContractData: jest.fn().mockResolvedValue({
+            val: {
+              contractData: () => ({
+                val: () =>
+                  nativeToScVal(
+                    TEST_DELEGATE_KEY,
+                    { type: 'address' },
+                  ),
+              }),
+            },
+          }),
+        };
+
+        return operation(fakeRpcServer as any);
+      });
+
+    await expect(
+      service.getDelegationForUser(
+        TEST_PUBLIC_KEY,
+      ),
+    ).resolves.toBe(TEST_DELEGATE_KEY);
+  });
+
+  it('should return null when contract data is missing for all candidate keys', async () => {
+    jest
+      .spyOn(mockRpcClient, 'executeWithRetry')
+      .mockImplementation(async (operation) => {
+        const fakeRpcServer = {
+          getContractData: jest.fn().mockRejectedValue({
+            code: 404,
+            message: 'missing',
+          }),
+        };
+
+        return operation(fakeRpcServer as any);
+      });
+
+    await expect(
+      service.getDelegationForUser(
+        TEST_PUBLIC_KEY,
+      ),
+    ).resolves.toBeNull();
   });
 });

--- a/backend/src/modules/blockchain/stellar.service.ts
+++ b/backend/src/modules/blockchain/stellar.service.ts
@@ -6,11 +6,20 @@ import {
   Keypair,
   Networks,
   rpc,
+  scValToNative,
   Transaction,
+  nativeToScVal,
   xdr,
 } from '@stellar/stellar-sdk';
 import { TransactionDto } from './dto/transaction.dto';
 import { RpcClientWrapper, RpcEndpoint } from './rpc-client.wrapper';
+
+const DELEGATION_STORAGE_KEYS = [
+  'delegate',
+  'delegation',
+  'Delegate',
+  'Delegation',
+] as const;
 
 @Injectable()
 export class StellarService implements OnModuleInit {
@@ -119,6 +128,63 @@ export class StellarService implements OnModuleInit {
     return Promise.resolve();
   }
 
+  async getDelegationForUser(publicKey: string): Promise<string | null> {
+    const contractId = this.configService.get<string>('stellar.contractId');
+    if (!contractId || !publicKey) {
+      return null;
+    }
+
+    try {
+      return await this.rpcClient.executeWithRetry(
+        async (client) => {
+          const rpcServer = client as rpc.Server;
+
+          for (const storageKeyName of DELEGATION_STORAGE_KEYS) {
+            const storageKey = nativeToScVal([storageKeyName, publicKey], {
+              type: ['symbol', 'address'],
+            });
+
+            try {
+              const entry = await rpcServer.getContractData(
+                contractId,
+                storageKey,
+                rpc.Durability.Persistent,
+              );
+
+              const rawValue = entry.val.contractData().val();
+              const delegate = this.normalizeDelegationValue(
+                scValToNative(rawValue),
+              );
+
+              if (delegate) {
+                return delegate;
+              }
+
+              if (delegate === null) {
+                return null;
+              }
+            } catch (error) {
+              if (this.isContractDataMissing(error)) {
+                continue;
+              }
+
+              throw error;
+            }
+          }
+
+          return null;
+        },
+        'rpc',
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch delegation for ${publicKey}: ${(error as Error).message}`,
+        error,
+      );
+      return null;
+    }
+  }
+
   generateKeypair(): { publicKey: string; secretKey: string } {
     const keypair = Keypair.random();
     return {
@@ -213,5 +279,26 @@ export class StellarService implements OnModuleInit {
       );
       return [];
     }
+  }
+
+  private normalizeDelegationValue(value: unknown): string | null {
+    if (value === undefined || value === null || value === false) {
+      return null;
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+
+    return null;
+  }
+
+  private isContractDataMissing(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 404
+    );
   }
 }

--- a/backend/src/modules/governance/dto/delegation-response.dto.ts
+++ b/backend/src/modules/governance/dto/delegation-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DelegationResponseDto {
+  @ApiProperty({
+    description:
+      'The delegated wallet address when an active delegation is configured, otherwise null.',
+    nullable: true,
+    example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  })
+  delegate: string | null;
+}

--- a/backend/src/modules/governance/governance.controller.ts
+++ b/backend/src/modules/governance/governance.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { DelegationResponseDto } from './dto/delegation-response.dto';
+import { GovernanceService } from './governance.service';
+
+@ApiTags('governance')
+@ApiBearerAuth()
+@Controller('user')
+@UseGuards(JwtAuthGuard)
+export class GovernanceController {
+  constructor(private readonly governanceService: GovernanceService) {}
+
+  @Get('delegation')
+  @ApiOperation({
+    summary: 'Get the authenticated user delegation target',
+    description:
+      'Reads the Soroban governance contract mapping for the authenticated user and returns the delegated wallet address when present.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Delegation lookup result',
+    type: DelegationResponseDto,
+  })
+  getDelegation(
+    @CurrentUser() user: { id: string },
+  ): Promise<DelegationResponseDto> {
+    return this.governanceService.getUserDelegation(user.id);
+  }
+}

--- a/backend/src/modules/governance/governance.module.ts
+++ b/backend/src/modules/governance/governance.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GovernanceController } from './governance.controller';
+import { GovernanceService } from './governance.service';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [UserModule],
+  controllers: [GovernanceController],
+  providers: [GovernanceService],
+})
+export class GovernanceModule {}

--- a/backend/src/modules/governance/governance.service.spec.ts
+++ b/backend/src/modules/governance/governance.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GovernanceService } from './governance.service';
+import { UserService } from '../user/user.service';
+import { StellarService } from '../blockchain/stellar.service';
+
+describe('GovernanceService', () => {
+  let service: GovernanceService;
+  let userService: { findById: jest.Mock };
+  let stellarService: { getDelegationForUser: jest.Mock };
+
+  beforeEach(async () => {
+    userService = {
+      findById: jest.fn(),
+    };
+
+    stellarService = {
+      getDelegationForUser: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GovernanceService,
+        {
+          provide: UserService,
+          useValue: userService,
+        },
+        {
+          provide: StellarService,
+          useValue: stellarService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GovernanceService>(GovernanceService);
+  });
+
+  it('returns null when the user has no linked wallet', async () => {
+    userService.findById.mockResolvedValue({ id: 'user-1', publicKey: null });
+
+    await expect(service.getUserDelegation('user-1')).resolves.toEqual({
+      delegate: null,
+    });
+    expect(stellarService.getDelegationForUser).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no delegation exists on-chain', async () => {
+    userService.findById.mockResolvedValue({
+      id: 'user-1',
+      publicKey: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    });
+    stellarService.getDelegationForUser.mockResolvedValue(null);
+
+    await expect(service.getUserDelegation('user-1')).resolves.toEqual({
+      delegate: null,
+    });
+  });
+
+  it('returns the delegated wallet address when present', async () => {
+    userService.findById.mockResolvedValue({
+      id: 'user-1',
+      publicKey: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    });
+    stellarService.getDelegationForUser.mockResolvedValue(
+      'GB7TAYQB6A6E7MCCKRUYJ4JYK2YTHJOTD4A5Q65XAH2EJQ2F6J67P5ST',
+    );
+
+    await expect(service.getUserDelegation('user-1')).resolves.toEqual({
+      delegate: 'GB7TAYQB6A6E7MCCKRUYJ4JYK2YTHJOTD4A5Q65XAH2EJQ2F6J67P5ST',
+    });
+  });
+});

--- a/backend/src/modules/governance/governance.service.ts
+++ b/backend/src/modules/governance/governance.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { StellarService } from '../blockchain/stellar.service';
+import { UserService } from '../user/user.service';
+import { DelegationResponseDto } from './dto/delegation-response.dto';
+
+@Injectable()
+export class GovernanceService {
+  constructor(
+    private readonly userService: UserService,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  async getUserDelegation(userId: string): Promise<DelegationResponseDto> {
+    const user = await this.userService.findById(userId);
+
+    if (!user.publicKey) {
+      return { delegate: null };
+    }
+
+    const delegate = await this.stellarService.getDelegationForUser(
+      user.publicKey,
+    );
+
+    return { delegate };
+  }
+}


### PR DESCRIPTION

This PR adds governance delegate lookup in `governance.service.ts` and introduces a reusable Soroban contract-data reader in `stellar.service.ts`.

## What changed
- Implemented delegate lookup against Soroban contract storage
- Added a reusable contract-data reader for Soroban RPC-backed storage reads
- Delegate resolution now:
  - queries the configured `stellar.contractId`
  - checks multiple safe delegation key shapes
  - returns `{ delegate: null }` when delegation is missing or explicitly disabled
  - returns the delegated wallet string when delegation is active

## Why
Governance delegation should be resolved from the source of truth on-chain. This change makes delegation lookup explicit, reliable, and reusable, while also providing a shared Soroban storage-read utility for future integrations.

## Notes
- Uses Soroban RPC to query contract data
- Handles absent and falsey delegation states safely
- Returns a normalized response shape for consumers


closes #307 