### PR TITLE
feat: implement Goal Analytics Computation

### DIFF
--- a/backend/src/modules/savings/savings.controller.ts
+++ b/backend/src/modules/savings/savings.controller.ts
@@ -20,6 +20,7 @@ import { UserSubscription } from './entities/user-subscription.entity';
 import { SubscribeDto } from './dto/subscribe.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { SavingsGoalProgress } from './savings.service';
 
 @ApiTags('savings')
 @Controller('savings')
@@ -59,5 +60,24 @@ export class SavingsController {
     @CurrentUser() user: { id: string; email: string },
   ): Promise<UserSubscription[]> {
     return await this.savingsService.findMySubscriptions(user.id);
+  }
+
+  @Get('my-goals')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Get current user savings goals enriched with live Soroban balance progress',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'List of savings goals with current balance and percentage completion',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyGoals(
+    @CurrentUser() user: { id: string; email: string },
+  ): Promise<SavingsGoalProgress[]> {
+    return await this.savingsService.findMyGoals(user.id);
   }
 }

--- a/backend/src/modules/savings/savings.module.ts
+++ b/backend/src/modules/savings/savings.module.ts
@@ -5,14 +5,19 @@ import { SavingsService } from './savings.service';
 import { SavingsProduct } from './entities/savings-product.entity';
 import { UserSubscription } from './entities/user-subscription.entity';
 import { SavingsGoal } from './entities/savings-goal.entity';
+import { User } from '../user/entities/user.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([SavingsProduct, UserSubscription, SavingsGoal]),
+    TypeOrmModule.forFeature([
+      SavingsProduct,
+      UserSubscription,
+      SavingsGoal,
+      User,
+    ]),
   ],
   controllers: [SavingsController],
   providers: [SavingsService],
   exports: [SavingsService],
 })
 export class SavingsModule {}
-

--- a/backend/src/modules/savings/savings.service.spec.ts
+++ b/backend/src/modules/savings/savings.service.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SavingsService } from './savings.service';
+import { SavingsProduct } from './entities/savings-product.entity';
+import { UserSubscription } from './entities/user-subscription.entity';
+import {
+  SavingsGoal,
+  SavingsGoalStatus,
+} from './entities/savings-goal.entity';
+import { User } from '../user/entities/user.entity';
+import { SavingsService as BlockchainSavingsService } from '../blockchain/savings.service';
+
+describe('SavingsService', () => {
+  let service: SavingsService;
+  let goalRepository: { find: jest.Mock };
+  let userRepository: { findOne: jest.Mock };
+  let blockchainSavingsService: { getUserSavingsBalance: jest.Mock };
+
+  beforeEach(async () => {
+    goalRepository = {
+      find: jest.fn(),
+    };
+
+    userRepository = {
+      findOne: jest.fn(),
+    };
+
+    blockchainSavingsService = {
+      getUserSavingsBalance: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SavingsService,
+        {
+          provide: getRepositoryToken(SavingsProduct),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(UserSubscription),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(SavingsGoal),
+          useValue: goalRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: userRepository,
+        },
+        {
+          provide: BlockchainSavingsService,
+          useValue: blockchainSavingsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SavingsService>(SavingsService);
+  });
+
+  it('returns goals enriched with percentageComplete from live vault balances', async () => {
+    goalRepository.find.mockResolvedValue([
+      {
+        id: 'goal-1',
+        userId: 'user-1',
+        goalName: 'Emergency Fund',
+        targetAmount: 100,
+        targetDate: new Date('2026-12-31'),
+        status: SavingsGoalStatus.IN_PROGRESS,
+        metadata: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+      },
+    ]);
+    userRepository.findOne.mockResolvedValue({
+      id: 'user-1',
+      publicKey: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    });
+    blockchainSavingsService.getUserSavingsBalance.mockResolvedValue({
+      flexible: 24_000_000,
+      locked: 50_000_000,
+      total: 74_000_000,
+    });
+
+    await expect(service.findMyGoals('user-1')).resolves.toEqual([
+      expect.objectContaining({
+        id: 'goal-1',
+        goalName: 'Emergency Fund',
+        targetAmount: 100,
+        currentBalance: 7.4,
+        percentageComplete: 7,
+      }),
+    ]);
+  });
+
+  it('returns 0 progress when the user has no linked wallet', async () => {
+    goalRepository.find.mockResolvedValue([
+      {
+        id: 'goal-1',
+        userId: 'user-1',
+        goalName: 'Vacation',
+        targetAmount: 10,
+        targetDate: new Date('2026-12-31'),
+        status: SavingsGoalStatus.IN_PROGRESS,
+        metadata: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+      },
+    ]);
+    userRepository.findOne.mockResolvedValue({
+      id: 'user-1',
+      publicKey: null,
+    });
+
+    await expect(service.findMyGoals('user-1')).resolves.toEqual([
+      expect.objectContaining({
+        currentBalance: 0,
+        percentageComplete: 0,
+      }),
+    ]);
+    expect(blockchainSavingsService.getUserSavingsBalance).not.toHaveBeenCalled();
+  });
+
+  it('caps progress at 100 percent', async () => {
+    goalRepository.find.mockResolvedValue([
+      {
+        id: 'goal-1',
+        userId: 'user-1',
+        goalName: 'New Laptop',
+        targetAmount: 5,
+        targetDate: new Date('2026-12-31'),
+        status: SavingsGoalStatus.COMPLETED,
+        metadata: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+      },
+    ]);
+    userRepository.findOne.mockResolvedValue({
+      id: 'user-1',
+      publicKey: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    });
+    blockchainSavingsService.getUserSavingsBalance.mockResolvedValue({
+      flexible: 40_000_000,
+      locked: 20_000_000,
+      total: 60_000_000,
+    });
+
+    await expect(service.findMyGoals('user-1')).resolves.toEqual([
+      expect.objectContaining({
+        currentBalance: 6,
+        percentageComplete: 100,
+      }),
+    ]);
+  });
+});

--- a/backend/src/modules/savings/savings.service.ts
+++ b/backend/src/modules/savings/savings.service.ts
@@ -11,8 +11,30 @@ import {
   UserSubscription,
   SubscriptionStatus,
 } from './entities/user-subscription.entity';
+import {
+  SavingsGoal,
+  SavingsGoalStatus,
+} from './entities/savings-goal.entity';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import { User } from '../user/entities/user.entity';
+import { SavingsService as BlockchainSavingsService } from '../blockchain/savings.service';
+
+export interface SavingsGoalProgress {
+  id: string;
+  userId: string;
+  goalName: string;
+  targetAmount: number;
+  targetDate: Date;
+  status: SavingsGoalStatus;
+  metadata: SavingsGoal['metadata'];
+  createdAt: Date;
+  updatedAt: Date;
+  currentBalance: number;
+  percentageComplete: number;
+}
+
+const STROOPS_PER_XLM = 10_000_000;
 
 @Injectable()
 export class SavingsService {
@@ -23,6 +45,11 @@ export class SavingsService {
     private readonly productRepository: Repository<SavingsProduct>,
     @InjectRepository(UserSubscription)
     private readonly subscriptionRepository: Repository<UserSubscription>,
+    @InjectRepository(SavingsGoal)
+    private readonly goalRepository: Repository<SavingsGoal>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly blockchainSavingsService: BlockchainSavingsService,
   ) {}
 
   async createProduct(dto: CreateProductDto): Promise<SavingsProduct> {
@@ -103,5 +130,79 @@ export class SavingsService {
       where: { userId },
       order: { createdAt: 'DESC' },
     });
+  }
+
+  async findMyGoals(userId: string): Promise<SavingsGoalProgress[]> {
+    const [goals, user] = await Promise.all([
+      this.goalRepository.find({
+        where: { userId },
+        order: { createdAt: 'DESC' },
+      }),
+      this.userRepository.findOne({
+        where: { id: userId },
+        select: ['id', 'publicKey'],
+      }),
+    ]);
+
+    if (!goals.length) {
+      return [];
+    }
+
+    const liveVaultBalanceStroops = user?.publicKey
+      ? (await this.blockchainSavingsService.getUserSavingsBalance(user.publicKey))
+          .total
+      : 0;
+
+    return goals.map((goal) =>
+      this.mapGoalWithProgress(goal, liveVaultBalanceStroops),
+    );
+  }
+
+  private mapGoalWithProgress(
+    goal: SavingsGoal,
+    liveVaultBalanceStroops: number,
+  ): SavingsGoalProgress {
+    const targetAmount = Number(goal.targetAmount);
+    const currentBalance = this.stroopsToDecimal(liveVaultBalanceStroops);
+    const percentageComplete = this.calculatePercentageComplete(
+      liveVaultBalanceStroops,
+      targetAmount,
+    );
+
+    return {
+      id: goal.id,
+      userId: goal.userId,
+      goalName: goal.goalName,
+      targetAmount,
+      targetDate: goal.targetDate,
+      status: goal.status,
+      metadata: goal.metadata,
+      createdAt: goal.createdAt,
+      updatedAt: goal.updatedAt,
+      currentBalance,
+      percentageComplete,
+    };
+  }
+
+  private calculatePercentageComplete(
+    liveVaultBalanceStroops: number,
+    targetAmount: number,
+  ): number {
+    if (targetAmount <= 0) {
+      return 0;
+    }
+
+    const targetAmountStroops = Math.round(targetAmount * STROOPS_PER_XLM);
+    if (targetAmountStroops <= 0) {
+      return 0;
+    }
+
+    const percentage = (liveVaultBalanceStroops / targetAmountStroops) * 100;
+
+    return Math.max(0, Math.min(100, Math.round(percentage)));
+  }
+
+  private stroopsToDecimal(amountInStroops: number): number {
+    return Number((amountInStroops / STROOPS_PER_XLM).toFixed(2));
   }
 }


### PR DESCRIPTION

This PR adds live goal-progress mapping to the savings backend. The service now combines database goal records with the user’s linked wallet and live Soroban savings balance, then returns enriched goal objects with `currentBalance` and `percentageComplete`.

## What changed
- Implemented goal-progress mapping in `savings.service.ts`
- Added `GET /savings/my-goals` in `savings.controller.ts`
- Updated `savings.module.ts` with the required repositories
- Added tests in `savings.service.spec.ts`

## Behavior
For each user goal, the service now:
- loads the goal from the database
- resolves the linked wallet
- pulls the live Soroban savings balance
- computes and returns:
  - `currentBalance`
  - `percentageComplete`

## Assumption
`targetAmount` is currently treated as an XLM-style decimal amount, and Soroban balances are normalized from stroops before progress is calculated.


closes #312 