### PR TITLE
feat(backend): add deposit event payload extractor for indexer

### DIFF
--- a/backend/src/migrations/1761300000000-CreateTransactionsLedger.ts
+++ b/backend/src/migrations/1761300000000-CreateTransactionsLedger.ts
@@ -1,0 +1,99 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateTransactionsLedger1761300000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'transactions',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'userId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'type',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'amount',
+            type: 'decimal',
+            precision: 20,
+            scale: 7,
+            isNullable: false,
+          },
+          {
+            name: 'publicKey',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'eventId',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'transactionHash',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'ledgerSequence',
+            type: 'bigint',
+            isNullable: true,
+          },
+          {
+            name: 'metadata',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['userId'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'transactions',
+      new TableIndex({
+        name: 'IDX_TRANSACTIONS_USER_ID',
+        columnNames: ['userId'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'transactions',
+      new TableIndex({
+        name: 'IDX_TRANSACTIONS_EVENT_ID_UNIQUE',
+        columnNames: ['eventId'],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('transactions');
+  }
+}

--- a/backend/src/modules/blockchain/blockchain.module.ts
+++ b/backend/src/modules/blockchain/blockchain.module.ts
@@ -6,13 +6,41 @@ import { BlockchainController } from './blockchain.controller';
 import { StellarEventListenerService } from './stellar-event-listener.service';
 import { StellarEventListenerController } from './stellar-event-listener.controller';
 import { ProcessedStellarEvent } from './entities/processed-event.entity';
+import { LedgerTransaction } from './entities/transaction.entity';
+import { DeadLetterEvent } from './entities/dead-letter-event.entity';
 import { MedicalClaim } from '../claims/entities/medical-claim.entity';
+import { User } from '../user/entities/user.entity';
+import { UserSubscription } from '../savings/entities/user-subscription.entity';
+import { SavingsProduct } from '../savings/entities/savings-product.entity';
+import { DepositHandler } from './event-handlers/deposit.handler';
+import { IndexerService } from './indexer.service';
 
 @Global()
 @Module({
-  imports: [TypeOrmModule.forFeature([ProcessedStellarEvent, MedicalClaim])],
+  imports: [
+    TypeOrmModule.forFeature([
+      ProcessedStellarEvent,
+      MedicalClaim,
+      LedgerTransaction,
+      DeadLetterEvent,
+      User,
+      UserSubscription,
+      SavingsProduct,
+    ]),
+  ],
   controllers: [BlockchainController, StellarEventListenerController],
-  providers: [StellarService, SavingsService, StellarEventListenerService],
-  exports: [StellarService, SavingsService, StellarEventListenerService],
+  providers: [
+    StellarService,
+    SavingsService,
+    StellarEventListenerService,
+    IndexerService,
+    DepositHandler,
+  ],
+  exports: [
+    StellarService,
+    SavingsService,
+    StellarEventListenerService,
+    DepositHandler,
+  ],
 })
 export class BlockchainModule {}

--- a/backend/src/modules/blockchain/entities/transaction.entity.ts
+++ b/backend/src/modules/blockchain/entities/transaction.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum LedgerTransactionType {
+  DEPOSIT = 'DEPOSIT',
+}
+
+@Entity('transactions')
+export class LedgerTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index('idx_transactions_user_id')
+  @Column('uuid')
+  userId: string;
+
+  @Column({ type: 'enum', enum: LedgerTransactionType })
+  type: LedgerTransactionType;
+
+  @Column('decimal', { precision: 20, scale: 7 })
+  amount: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  publicKey: string | null;
+
+  @Index('idx_transactions_event_id', { unique: true })
+  @Column({ type: 'varchar' })
+  eventId: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  transactionHash: string | null;
+
+  @Column({ type: 'bigint', nullable: true })
+  ledgerSequence: string | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/modules/blockchain/event-handlers/deposit.handler.ts
+++ b/backend/src/modules/blockchain/event-handlers/deposit.handler.ts
@@ -1,0 +1,253 @@
+import { createHash } from 'crypto';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { scValToNative, xdr } from '@stellar/stellar-sdk';
+import {
+  LedgerTransaction,
+  LedgerTransactionType,
+} from '../entities/transaction.entity';
+import {
+  SubscriptionStatus,
+  UserSubscription,
+} from '../../savings/entities/user-subscription.entity';
+import { User } from '../../user/entities/user.entity';
+import { SavingsProduct } from '../../savings/entities/savings-product.entity';
+
+interface IndexerEvent {
+  id?: string;
+  topic?: unknown[];
+  value?: unknown;
+  txHash?: string;
+  ledger?: number;
+  [key: string]: unknown;
+}
+
+interface DepositPayload {
+  publicKey: string;
+  amount: string;
+}
+
+@Injectable()
+export class DepositHandler {
+  private readonly logger = new Logger(DepositHandler.name);
+  private static readonly DEPOSIT_HASH_HEX = createHash('sha256')
+    .update('Deposit')
+    .digest('hex');
+
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async handle(event: IndexerEvent): Promise<boolean> {
+    if (!this.isDepositTopic(event.topic)) {
+      return false;
+    }
+
+    const payload = this.extractPayload(event.value);
+    const eventId = this.resolveEventId(event);
+
+    await this.dataSource.transaction(async (manager) => {
+      const userRepo = manager.getRepository(User);
+      const txRepo = manager.getRepository(LedgerTransaction);
+      const subRepo = manager.getRepository(UserSubscription);
+      const productRepo = manager.getRepository(SavingsProduct);
+
+      const user = await userRepo.findOne({
+        where: [{ publicKey: payload.publicKey }, { walletAddress: payload.publicKey }],
+      });
+
+      if (!user) {
+        throw new Error(
+          `Cannot map deposit payload publicKey to user: ${payload.publicKey}`,
+        );
+      }
+
+      const existingTx = await txRepo.findOne({ where: { eventId } });
+      if (existingTx) {
+        this.logger.debug(`Deposit event ${eventId} already persisted. Skipping.`);
+        return;
+      }
+
+      await txRepo.save(
+        txRepo.create({
+          userId: user.id,
+          type: LedgerTransactionType.DEPOSIT,
+          amount: payload.amount,
+          publicKey: payload.publicKey,
+          eventId,
+          transactionHash:
+            typeof event.txHash === 'string' ? event.txHash : null,
+          ledgerSequence:
+            typeof event.ledger === 'number' ? String(event.ledger) : null,
+          metadata: {
+            topic: event.topic,
+            rawValueType: typeof event.value,
+          },
+        }),
+      );
+
+      const amountAsNumber = Number(payload.amount);
+
+      let subscription = await subRepo.findOne({
+        where: {
+          userId: user.id,
+          status: SubscriptionStatus.ACTIVE,
+        },
+        order: { createdAt: 'DESC' },
+      });
+
+      if (!subscription) {
+        const defaultProduct = user.defaultSavingsProductId
+          ? await productRepo.findOne({ where: { id: user.defaultSavingsProductId } })
+          : await productRepo.findOne({
+              where: { isActive: true },
+              order: { createdAt: 'ASC' },
+            });
+
+        if (!defaultProduct) {
+          throw new Error('No savings product found to create subscription aggregate.');
+        }
+
+        subscription = subRepo.create({
+          userId: user.id,
+          productId: defaultProduct.id,
+          amount: amountAsNumber,
+          status: SubscriptionStatus.ACTIVE,
+          startDate: new Date(),
+          endDate: null,
+        });
+      } else {
+        subscription.amount = Number(subscription.amount) + amountAsNumber;
+      }
+
+      await subRepo.save(subscription);
+    });
+
+    return true;
+  }
+
+  private isDepositTopic(topic: unknown[] | undefined): boolean {
+    if (!Array.isArray(topic) || topic.length === 0) {
+      return false;
+    }
+
+    const first = topic[0];
+    const normalized = this.toHex(first);
+    return normalized === DepositHandler.DEPOSIT_HASH_HEX;
+  }
+
+  private extractPayload(value: unknown): DepositPayload {
+    const decoded = this.decodeScVal(value);
+    const asRecord = this.ensureObject(decoded);
+
+    const publicKey =
+      this.pickString(asRecord, ['publicKey', 'userPublicKey', 'user', 'address']) ??
+      '';
+    const amountRaw = asRecord['amount'];
+
+    const amount =
+      typeof amountRaw === 'bigint'
+        ? amountRaw.toString()
+        : typeof amountRaw === 'number'
+          ? String(amountRaw)
+          : typeof amountRaw === 'string'
+            ? amountRaw
+            : '';
+
+    if (!publicKey || !amount || Number.isNaN(Number(amount))) {
+      throw new Error('Invalid Deposit payload: expected publicKey + numeric amount');
+    }
+
+    return { publicKey, amount };
+  }
+
+  private resolveEventId(event: IndexerEvent): string {
+    if (typeof event.id === 'string' && event.id.length > 0) {
+      return event.id;
+    }
+
+    const txHash = typeof event.txHash === 'string' ? event.txHash : 'unknown';
+    const ledger = typeof event.ledger === 'number' ? event.ledger : 0;
+    return `${txHash}:${ledger}:deposit`;
+  }
+
+  private decodeScVal(value: unknown): unknown {
+    if (
+      value &&
+      typeof value === 'object' &&
+      'toXDR' in value &&
+      typeof (value as { toXDR?: unknown }).toXDR === 'function'
+    ) {
+      const base64 = (value as { toXDR: (encoding?: string) => string }).toXDR(
+        'base64',
+      );
+      const scVal = xdr.ScVal.fromXDR(base64, 'base64');
+      return scValToNative(scVal);
+    }
+
+    if (typeof value === 'string') {
+      try {
+        const scVal = xdr.ScVal.fromXDR(value, 'base64');
+        return scValToNative(scVal);
+      } catch {
+        return value;
+      }
+    }
+
+    return value;
+  }
+
+  private ensureObject(value: unknown): Record<string, unknown> {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+
+    throw new Error('Unexpected Deposit payload shape.');
+  }
+
+  private pickString(
+    record: Record<string, unknown>,
+    keys: string[],
+  ): string | null {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+  private toHex(topicPart: unknown): string | null {
+    if (typeof topicPart === 'string') {
+      const clean = topicPart.toLowerCase().replace(/^0x/, '');
+      if (/^[0-9a-f]{64}$/i.test(clean)) {
+        return clean;
+      }
+
+      try {
+        return Buffer.from(topicPart, 'base64').toString('hex');
+      } catch {
+        return null;
+      }
+    }
+
+    if (
+      topicPart &&
+      typeof topicPart === 'object' &&
+      'toXDR' in topicPart &&
+      typeof (topicPart as { toXDR?: unknown }).toXDR === 'function'
+    ) {
+      try {
+        const base64 = (topicPart as { toXDR: (encoding?: string) => string }).toXDR(
+          'base64',
+        );
+        return Buffer.from(base64, 'base64').toString('hex');
+      } catch {
+        return null;
+      }
+    }
+
+    return null;
+  }
+}

--- a/backend/src/modules/blockchain/indexer.service.ts
+++ b/backend/src/modules/blockchain/indexer.service.ts
@@ -3,10 +3,15 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Interval } from '@nestjs/schedule';
 import { DeadLetterEvent } from './entities/dead-letter-event.entity';
+import { DepositHandler } from './event-handlers/deposit.handler';
 
 /** Shape of a raw Soroban event as returned by the RPC. */
 interface SorobanEvent {
+  id?: string;
   ledger: number;
+  topic?: unknown[];
+  value?: unknown;
+  txHash?: string;
   [key: string]: unknown;
 }
 
@@ -18,6 +23,7 @@ export class IndexerService implements OnModuleInit {
   constructor(
     @InjectRepository(DeadLetterEvent)
     private readonly dlqRepo: Repository<DeadLetterEvent>,
+    private readonly depositHandler: DepositHandler,
   ) {}
 
   onModuleInit() {
@@ -75,7 +81,14 @@ export class IndexerService implements OnModuleInit {
    */
   private async handleEvent(event: SorobanEvent): Promise<void> {
     this.logger.debug(`Processing event at ledger=${event.ledger}`);
-    // TODO: dispatch to domain-specific handlers (e.g. governance, savings)
+
+    const handledByDeposit = await this.depositHandler.handle(event);
+    if (handledByDeposit) {
+      this.logger.debug(`Handled deposit event at ledger=${event.ledger}`);
+      return;
+    }
+
+    // TODO: dispatch to other domain-specific handlers.
   }
 
   /** Fetches new Soroban events from the RPC since the last processed ledger. */


### PR DESCRIPTION
PR Title:
feat(backend): add deposit payload extractor for indexer events

## Summary
This PR implements issue #289 by adding a backend indexer handler for Soroban Deposit events so database state mirrors on-chain deposit activity.

## What Changed
- Added a dedicated deposit event handler:
  - `backend/src/modules/blockchain/event-handlers/deposit.handler.ts`
  - Verifies event topic against the 32-byte Deposit hash
  - Decodes Soroban custom payload to extract `publicKey` and `amount`
  - Executes a TypeORM transaction for atomic DB updates

- Added transaction ledger persistence:
  - `backend/src/modules/blockchain/entities/transaction.entity.ts`
  - Inserts transaction rows with type `DEPOSIT`

- Added migration for the transaction ledger table:
  - `backend/src/migrations/1761300000000-CreateTransactionsLedger.ts`

- Wired handler into indexer and module:
  - `backend/src/modules/blockchain/indexer.service.ts`
  - `backend/src/modules/blockchain/blockchain.module.ts`

## Acceptance Criteria Mapping
- [x] Check emitted topic matches 32-byte Deposit hash
- [x] Decode Soroban payload with user `publicKey` and integer `amount`
- [x] Use TypeORM transaction to:
  - insert Transaction row (`DEPOSIT`)
  - increment/create UserSubscription aggregate

## Validation
- Backend builds successfully (`pnpm run build` in `backend/`)


Closes #289
