### PR TITLE
Add reusable GoalCard component and savings page grid

### DIFF
--- a/frontend/app/savings/components/GoalCard.tsx
+++ b/frontend/app/savings/components/GoalCard.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import React, { ReactNode } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+
+export type GoalStatus = 'active' | 'near-deadline' | 'behind-schedule' | 'paused';
+
+interface GoalCardProps {
+  icon: ReactNode;
+  title: string;
+  status: GoalStatus;
+  targetAmount: string;
+  currentSaved: string;
+  remainingAmount: string;
+  progressPercent: number;
+  scheduleLabel: string;
+  contributionFrequency: string;
+  nextContributionLabel: string;
+  nextContributionValue: string;
+  onAddFunds?: () => void;
+  onViewDetails?: () => void;
+  onOverflowAction?: () => void;
+}
+
+const statusStyles: Record<GoalStatus, { label: string; className: string }> = {
+  active: {
+    label: 'Active',
+    className: 'bg-emerald-500/15 border-emerald-400/30 text-emerald-200',
+  },
+  'near-deadline': {
+    label: 'Near Deadline',
+    className: 'bg-amber-500/15 border-amber-400/30 text-amber-200',
+  },
+  'behind-schedule': {
+    label: 'Behind Schedule',
+    className: 'bg-rose-500/15 border-rose-400/30 text-rose-200',
+  },
+  paused: {
+    label: 'Paused',
+    className: 'bg-slate-600/20 border-slate-500/30 text-slate-200',
+  },
+};
+
+const progressBarColor: Record<GoalStatus, string> = {
+  active: 'bg-emerald-400',
+  'near-deadline': 'bg-amber-400',
+  'behind-schedule': 'bg-rose-400',
+  paused: 'bg-slate-400',
+};
+
+export default function GoalCard({
+  icon,
+  title,
+  status,
+  targetAmount,
+  currentSaved,
+  remainingAmount,
+  progressPercent,
+  scheduleLabel,
+  contributionFrequency,
+  nextContributionLabel,
+  nextContributionValue,
+  onAddFunds,
+  onViewDetails,
+  onOverflowAction,
+}: GoalCardProps) {
+  const safeProgress = Math.max(0, Math.min(100, progressPercent));
+  const statusInfo = statusStyles[status];
+
+  return (
+    <article className="rounded-2xl border border-white/10 bg-[#0d2425] p-5 shadow-[0_12px_30px_rgba(2,12,12,0.45)]">
+      <div className="flex items-start gap-3">
+        <div className="w-12 h-12 rounded-xl bg-[#0f3b3a] flex items-center justify-center text-cyan-300">
+          {icon}
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-semibold text-white leading-snug">{title}</h3>
+          <div className={`inline-flex items-center gap-2 px-2 py-1 mt-2 rounded-full border text-xs font-medium ${statusInfo.className}`}>
+            <span>{statusInfo.label}</span>
+          </div>
+        </div>
+        <button
+          onClick={onOverflowAction}
+          aria-label="More actions"
+          className="text-slate-400 hover:text-white transition"
+        >
+          <MoreHorizontal size={18} />
+        </button>
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+        <div>
+          <p className="text-[#6a8a93] text-[11px] uppercase tracking-wider">Target</p>
+          <p className="text-white font-semibold">{targetAmount}</p>
+        </div>
+        <div>
+          <p className="text-[#6a8a93] text-[11px] uppercase tracking-wider">Saved</p>
+          <p className="text-white font-semibold">{currentSaved}</p>
+        </div>
+        <div>
+          <p className="text-[#6a8a93] text-[11px] uppercase tracking-wider">Remaining</p>
+          <p className="text-white font-semibold">{remainingAmount}</p>
+        </div>
+        <div>
+          <p className="text-[#6a8a93] text-[11px] uppercase tracking-wider">Schedule</p>
+          <p className="text-white font-semibold">{scheduleLabel}</p>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="w-full h-2 rounded-full bg-white/10 overflow-hidden">
+          <div
+            className={`h-full ${progressBarColor[status]}`}
+            style={{ width: `${safeProgress}%` }}
+          />
+        </div>
+        <p className="mt-2 text-xs text-slate-300">Progress: <span className="text-white font-semibold">{safeProgress}%</span></p>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+        <div>
+          <p className="text-[#6a8a93] text-[11px] uppercase tracking-wider">Frequency</p>
+          <p className="text-white font-semibold">{contributionFrequency}</p>
+        </div>
+        <div>
+          <p className="text-[#6a8a93] text-[11px] uppercase tracking-wider">{nextContributionLabel}</p>
+          <p className="text-white font-semibold">{nextContributionValue}</p>
+        </div>
+      </div>
+
+      <div className="mt-5 flex items-center gap-2">
+        <button
+          onClick={onAddFunds}
+          className="flex-1 rounded-lg bg-cyan-500 hover:bg-cyan-400 text-[#061a1a] font-semibold px-3 py-2 transition-all active:scale-95"
+        >
+          Add Funds
+        </button>
+        <button
+          onClick={onViewDetails}
+          className="flex-1 rounded-lg border border-white/20 text-white hover:bg-white/5 px-3 py-2 transition-all active:scale-95"
+        >
+          View Details
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/frontend/app/savings/page.tsx
+++ b/frontend/app/savings/page.tsx
@@ -8,7 +8,12 @@ import {
   Trophy,
   Banknote,
   ArrowUp,
+  PiggyBank,
+  Home,
+  Airplane,
+  ShoppingBag,
 } from "lucide-react";
+import GoalCard, { GoalStatus } from "./components/GoalCard";
 
 // export const metadata = { title: "Goal-Based Savings - Nestera" };
 
@@ -90,6 +95,90 @@ export default function GoalBasedSavingsPage() {
                 {stat.value}
               </p>
             </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Goal cards grid */}
+      <div className="w-full max-w-7xl mx-auto px-6 md:px-8 pb-16">
+        <h2 className="text-xl md:text-2xl text-white font-bold mb-5">Your Savings Goals</h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
+          {[
+            {
+              id: '1',
+              icon: <PiggyBank size={20} />,
+              title: 'Emergency Fund',
+              status: 'active' as GoalStatus,
+              targetAmount: '$12,000',
+              currentSaved: '$6,400',
+              remainingAmount: '$5,600',
+              progressPercent: 53,
+              scheduleLabel: 'By Dec 20, 2026',
+              contributionFrequency: 'Weekly',
+              nextContributionLabel: 'Next contribution',
+              nextContributionValue: '$150 on Jun 28',
+            },
+            {
+              id: '2',
+              icon: <Home size={20} />,
+              title: 'Down Payment',
+              status: 'near-deadline' as GoalStatus,
+              targetAmount: '$40,000',
+              currentSaved: '$28,000',
+              remainingAmount: '$12,000',
+              progressPercent: 70,
+              scheduleLabel: 'Due Oct 03, 2026',
+              contributionFrequency: 'Monthly',
+              nextContributionLabel: 'Next contribution',
+              nextContributionValue: '$1,000 on Jul 01',
+            },
+            {
+              id: '3',
+              icon: <Airplane size={20} />,
+              title: 'Summer Trip',
+              status: 'behind-schedule' as GoalStatus,
+              targetAmount: '$8,000',
+              currentSaved: '$3,100',
+              remainingAmount: '$4,900',
+              progressPercent: 39,
+              scheduleLabel: 'By Aug 15, 2026',
+              contributionFrequency: 'Every other week',
+              nextContributionLabel: 'Next contribution',
+              nextContributionValue: '$250 on Jul 05',
+            },
+            {
+              id: '4',
+              icon: <ShoppingBag size={20} />,
+              title: 'New Laptop',
+              status: 'paused' as GoalStatus,
+              targetAmount: '$2,500',
+              currentSaved: '$1,500',
+              remainingAmount: '$1,000',
+              progressPercent: 60,
+              scheduleLabel: 'Paused until decision',
+              contributionFrequency: 'Paused',
+              nextContributionLabel: 'Next contribution',
+              nextContributionValue: 'N/A',
+            },
+          ].map((goal) => (
+            <GoalCard
+              key={goal.id}
+              icon={goal.icon}
+              title={goal.title}
+              status={goal.status}
+              targetAmount={goal.targetAmount}
+              currentSaved={goal.currentSaved}
+              remainingAmount={goal.remainingAmount}
+              progressPercent={goal.progressPercent}
+              scheduleLabel={goal.scheduleLabel}
+              contributionFrequency={goal.contributionFrequency}
+              nextContributionLabel={goal.nextContributionLabel}
+              nextContributionValue={goal.nextContributionValue}
+              onAddFunds={() => console.log('Add funds', goal.id)}
+              onViewDetails={() => console.log('View details', goal.id)}
+              onOverflowAction={() => console.log('More actions', goal.id)}
+            />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Closes #268 

### Summary
- Implemented a reusable `GoalCard` UI component for the Goal-Based Savings page.
- Added a responsive grid layout in page.tsx to render multiple goal cards from structured data.
- Included mock goals to demonstrate:
  - Active, Near Deadline, Behind Schedule, Paused variants
  - Target/saved/remaining values
  - Progress bar and percentage
  - Deadline/schedule and frequency/next contribution metadata
  - Primary `Add Funds`, secondary `View Details`, and overflow action handlers

### Files changed
- GoalCard.tsx
- page.tsx

### Behavior
- Fully prop-driven component (all card fields are passed via props).
- Status badge and progress bar colors change based on status.
- Card layout matches Figma style:
  - icon/title/status top row
  - data grid of amounts and timing
  - progress bar + percentage
  - action buttons
- Ready to replace mock goals with API data in a true multi-card grid.

### Impact
- Supports goal-card reuse across savings dashboard and other UIs.
- Establishes a single source for goal card logic/styles and improves consistency.
- Ready for continuation:
  - integrate with backend savings goal API payload
  - add unit tests for status variants and progress behavior
  - add overflow menu actions/UI state.