### PR TITLE
fix(contracts): harden treasury withdrawals with enforceable guardrails

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1017,6 +1017,31 @@ impl NesteraContract {
         treasury::get_reserve_balance(&env)
     }
 
+    /// Returns treasury withdrawal security limits.
+    pub fn get_treasury_limits(env: Env) -> treasury::types::TreasurySecurityConfig {
+        treasury::get_treasury_limits(&env)
+    }
+
+    /// Updates treasury withdrawal limits (admin only).
+    pub fn set_treasury_limits(
+        env: Env,
+        admin: Address,
+        max_withdrawal_per_tx: i128,
+        daily_withdrawal_cap: i128,
+    ) -> Result<treasury::types::TreasurySecurityConfig, SavingsError> {
+        treasury::set_treasury_limits(&env, &admin, max_withdrawal_per_tx, daily_withdrawal_cap)
+    }
+
+    /// Withdraws from a treasury pool with per-tx and daily caps (admin only).
+    pub fn withdraw_treasury(
+        env: Env,
+        admin: Address,
+        pool: treasury::types::TreasuryPool,
+        amount: i128,
+    ) -> Result<treasury::types::Treasury, SavingsError> {
+        treasury::withdraw_treasury(&env, &admin, pool, amount)
+    }
+
     /// Allocates the unallocated treasury balance into reserves, rewards, and operations.
     /// Percentages are in basis points and must sum to 10_000.
     pub fn allocate_treasury(

--- a/contracts/src/storage_types.rs
+++ b/contracts/src/storage_types.rs
@@ -149,6 +149,10 @@ pub enum DataKey {
     ConfigInitialized,
     /// Treasury allocation config (reserve/rewards/operations percentages)
     AllocationConfig,
+    /// Treasury security limits for admin withdrawals
+    TreasurySecurityConfig,
+    /// Daily treasury withdrawal tracker (timestamp + amount)
+    TreasuryDailyWithdrawal,
     /// Early break fee (basis points) for goal saves
     EarlyBreakFeeBps,
     /// Fee recipient for protocol/treasury fees

--- a/contracts/src/treasury/mod.rs
+++ b/contracts/src/treasury/mod.rs
@@ -1,12 +1,18 @@
 pub mod types;
 
 #[cfg(test)]
+mod security_tests;
+#[cfg(test)]
 mod views_tests;
 
 use crate::errors::SavingsError;
 use crate::storage_types::DataKey;
 use soroban_sdk::{symbol_short, Address, Env};
-use types::{AllocationConfig, Treasury};
+use types::{
+    AllocationConfig, Treasury, TreasuryDailyWithdrawal, TreasuryPool, TreasurySecurityConfig,
+};
+
+const TREASURY_DAILY_WINDOW_SECS: u64 = 24 * 60 * 60;
 
 // ========== Treasury Storage Helpers ==========
 
@@ -23,6 +29,59 @@ fn set_treasury(env: &Env, treasury: &Treasury) {
     env.storage().persistent().set(&DataKey::Treasury, treasury);
 }
 
+fn require_admin(env: &Env, admin: &Address) -> Result<(), SavingsError> {
+    let stored_admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(SavingsError::Unauthorized)?;
+    if stored_admin != *admin {
+        return Err(SavingsError::Unauthorized);
+    }
+    admin.require_auth();
+    Ok(())
+}
+
+fn validate_treasury_state(treasury: &Treasury) -> Result<(), SavingsError> {
+    if treasury.total_fees_collected < 0
+        || treasury.total_yield_earned < 0
+        || treasury.reserve_balance < 0
+        || treasury.treasury_balance < 0
+        || treasury.rewards_balance < 0
+        || treasury.operations_balance < 0
+    {
+        return Err(SavingsError::InvariantViolation);
+    }
+    Ok(())
+}
+
+fn get_treasury_limits_internal(env: &Env) -> TreasurySecurityConfig {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TreasurySecurityConfig)
+        .unwrap_or(TreasurySecurityConfig::default_limits())
+}
+
+fn set_treasury_limits_internal(env: &Env, limits: &TreasurySecurityConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TreasurySecurityConfig, limits);
+}
+
+fn get_daily_withdrawal_tracker(env: &Env) -> TreasuryDailyWithdrawal {
+    let now = env.ledger().timestamp();
+    env.storage()
+        .persistent()
+        .get(&DataKey::TreasuryDailyWithdrawal)
+        .unwrap_or(TreasuryDailyWithdrawal::new(now))
+}
+
+fn set_daily_withdrawal_tracker(env: &Env, tracker: &TreasuryDailyWithdrawal) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TreasuryDailyWithdrawal, tracker);
+}
+
 // ========== Treasury Initialization ==========
 
 /// Initializes the treasury with default zero values.
@@ -30,6 +89,8 @@ fn set_treasury(env: &Env, treasury: &Treasury) {
 pub fn initialize_treasury(env: &Env) {
     let treasury = Treasury::new();
     set_treasury(env, &treasury);
+    set_treasury_limits_internal(env, &TreasurySecurityConfig::default_limits());
+    set_daily_withdrawal_tracker(env, &TreasuryDailyWithdrawal::new(env.ledger().timestamp()));
 }
 
 // ========== Fee Recording ==========
@@ -45,14 +106,19 @@ pub fn record_fee(env: &Env, amount: i128, fee_type: soroban_sdk::Symbol) {
         return;
     }
     let mut treasury = get_treasury(env);
-    treasury.total_fees_collected = treasury
-        .total_fees_collected
-        .checked_add(amount)
-        .unwrap_or(treasury.total_fees_collected);
-    treasury.treasury_balance = treasury
-        .treasury_balance
-        .checked_add(amount)
-        .unwrap_or(treasury.treasury_balance);
+    if let Some(updated_total_fees) = treasury.total_fees_collected.checked_add(amount) {
+        treasury.total_fees_collected = updated_total_fees;
+    } else {
+        return;
+    }
+    if let Some(updated_treasury_balance) = treasury.treasury_balance.checked_add(amount) {
+        treasury.treasury_balance = updated_treasury_balance;
+    } else {
+        return;
+    }
+    if validate_treasury_state(&treasury).is_err() {
+        return;
+    }
     set_treasury(env, &treasury);
 
     env.events()
@@ -65,10 +131,14 @@ pub fn record_yield(env: &Env, amount: i128) {
         return;
     }
     let mut treasury = get_treasury(env);
-    treasury.total_yield_earned = treasury
-        .total_yield_earned
-        .checked_add(amount)
-        .unwrap_or(treasury.total_yield_earned);
+    if let Some(updated_total_yield) = treasury.total_yield_earned.checked_add(amount) {
+        treasury.total_yield_earned = updated_total_yield;
+    } else {
+        return;
+    }
+    if validate_treasury_state(&treasury).is_err() {
+        return;
+    }
     set_treasury(env, &treasury);
 }
 
@@ -92,6 +162,112 @@ pub fn get_total_yield(env: &Env) -> i128 {
 /// Returns the current reserve sub-balance (allocated funds held as reserve).
 pub fn get_reserve_balance(env: &Env) -> i128 {
     get_treasury(env).reserve_balance
+}
+
+/// Returns current treasury withdrawal safety limits.
+pub fn get_treasury_limits(env: &Env) -> TreasurySecurityConfig {
+    get_treasury_limits_internal(env)
+}
+
+/// Updates treasury withdrawal limits (admin only).
+pub fn set_treasury_limits(
+    env: &Env,
+    admin: &Address,
+    max_withdrawal_per_tx: i128,
+    daily_withdrawal_cap: i128,
+) -> Result<TreasurySecurityConfig, SavingsError> {
+    require_admin(env, admin)?;
+
+    if max_withdrawal_per_tx <= 0 || daily_withdrawal_cap <= 0 {
+        return Err(SavingsError::InvalidAmount);
+    }
+    if max_withdrawal_per_tx > daily_withdrawal_cap {
+        return Err(SavingsError::AmountExceedsLimit);
+    }
+
+    let limits = TreasurySecurityConfig {
+        max_withdrawal_per_tx,
+        daily_withdrawal_cap,
+    };
+    set_treasury_limits_internal(env, &limits);
+    env.events().publish(
+        (symbol_short!("trs_lim"),),
+        (max_withdrawal_per_tx, daily_withdrawal_cap),
+    );
+
+    Ok(limits)
+}
+
+/// Withdraws from a treasury sub-balance with per-tx and daily safety caps (admin only).
+pub fn withdraw_treasury(
+    env: &Env,
+    admin: &Address,
+    pool: TreasuryPool,
+    amount: i128,
+) -> Result<Treasury, SavingsError> {
+    require_admin(env, admin)?;
+    if amount <= 0 {
+        return Err(SavingsError::InvalidAmount);
+    }
+
+    let limits = get_treasury_limits_internal(env);
+    if amount > limits.max_withdrawal_per_tx {
+        return Err(SavingsError::AmountExceedsLimit);
+    }
+
+    let now = env.ledger().timestamp();
+    let mut daily = get_daily_withdrawal_tracker(env);
+    if now.saturating_sub(daily.window_start_ts) >= TREASURY_DAILY_WINDOW_SECS {
+        daily = TreasuryDailyWithdrawal::new(now);
+    }
+
+    let new_daily_total = daily
+        .withdrawn_amount
+        .checked_add(amount)
+        .ok_or(SavingsError::Overflow)?;
+    if new_daily_total > limits.daily_withdrawal_cap {
+        return Err(SavingsError::AmountExceedsLimit);
+    }
+
+    let mut treasury = get_treasury(env);
+    match pool.clone() {
+        TreasuryPool::Reserve => {
+            if amount > treasury.reserve_balance {
+                return Err(SavingsError::InsufficientBalance);
+            }
+            treasury.reserve_balance = treasury
+                .reserve_balance
+                .checked_sub(amount)
+                .ok_or(SavingsError::InsufficientBalance)?;
+        }
+        TreasuryPool::Rewards => {
+            if amount > treasury.rewards_balance {
+                return Err(SavingsError::InsufficientBalance);
+            }
+            treasury.rewards_balance = treasury
+                .rewards_balance
+                .checked_sub(amount)
+                .ok_or(SavingsError::InsufficientBalance)?;
+        }
+        TreasuryPool::Operations => {
+            if amount > treasury.operations_balance {
+                return Err(SavingsError::InsufficientBalance);
+            }
+            treasury.operations_balance = treasury
+                .operations_balance
+                .checked_sub(amount)
+                .ok_or(SavingsError::InsufficientBalance)?;
+        }
+    }
+
+    validate_treasury_state(&treasury)?;
+    daily.withdrawn_amount = new_daily_total;
+    set_treasury(env, &treasury);
+    set_daily_withdrawal_tracker(env, &daily);
+    env.events()
+        .publish((symbol_short!("trs_wth"),), (pool, amount, new_daily_total));
+
+    Ok(treasury)
 }
 
 // ========== Allocation Logic ==========
@@ -118,16 +294,7 @@ pub fn allocate_treasury(
     rewards_percent: u32,
     operations_percent: u32,
 ) -> Result<Treasury, SavingsError> {
-    // Verify admin
-    let stored_admin: Address = env
-        .storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .ok_or(SavingsError::Unauthorized)?;
-    if stored_admin != *admin {
-        return Err(SavingsError::Unauthorized);
-    }
-    admin.require_auth();
+    require_admin(env, admin)?;
 
     // Validate percentages sum to 100%
     let total = reserve_percent
@@ -177,6 +344,7 @@ pub fn allocate_treasury(
 
     // Zero out the unallocated balance
     treasury.treasury_balance = 0;
+    validate_treasury_state(&treasury)?;
 
     // Store the allocation config for reference
     let alloc_config = AllocationConfig {

--- a/contracts/src/treasury/security_tests.rs
+++ b/contracts/src/treasury/security_tests.rs
@@ -1,0 +1,196 @@
+use crate::treasury::types::TreasuryPool;
+use crate::{NesteraContract, NesteraContractClient, SavingsError};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, InvokeError,
+};
+
+fn setup() -> (
+    Env,
+    soroban_sdk::Address,
+    NesteraContractClient<'static>,
+    Address,
+) {
+    let env = Env::default();
+    let contract_id = env.register(NesteraContract, ());
+    let client = NesteraContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury_addr = Address::generate(&env);
+    let admin_pk = BytesN::from_array(&env, &[8u8; 32]);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin_pk);
+    client.initialize_config(&admin, &treasury_addr, &100u32, &100u32, &100u32);
+
+    (env, contract_id, client, admin)
+}
+
+fn seed_and_allocate(
+    env: &Env,
+    contract_id: &Address,
+    client: &NesteraContractClient<'_>,
+    admin: &Address,
+    fees: i128,
+    reserve_percent: u32,
+    rewards_percent: u32,
+    operations_percent: u32,
+) {
+    env.as_contract(contract_id, || {
+        crate::treasury::record_fee(env, fees, soroban_sdk::Symbol::new(env, "dep"));
+    });
+    client.allocate_treasury(
+        admin,
+        &reserve_percent,
+        &rewards_percent,
+        &operations_percent,
+    );
+}
+
+fn assert_savings_error(err: Result<SavingsError, InvokeError>, expected: SavingsError) {
+    assert_eq!(err, Ok(expected));
+}
+
+#[test]
+fn test_max_withdrawal_limit_per_transaction_enforced() {
+    let (env, contract_id, client, admin) = setup();
+    env.mock_all_auths();
+
+    seed_and_allocate(
+        &env,
+        &contract_id,
+        &client,
+        &admin,
+        20_000,
+        5_000,
+        3_000,
+        2_000,
+    );
+    client.set_treasury_limits(&admin, &1_000, &8_000);
+
+    assert_savings_error(
+        client
+            .try_withdraw_treasury(&admin, &TreasuryPool::Reserve, &1_001)
+            .unwrap_err(),
+        SavingsError::AmountExceedsLimit,
+    );
+}
+
+#[test]
+fn test_daily_withdrawal_cap_enforced_across_multiple_operations() {
+    let (env, contract_id, client, admin) = setup();
+    env.mock_all_auths();
+
+    seed_and_allocate(
+        &env,
+        &contract_id,
+        &client,
+        &admin,
+        30_000,
+        5_000,
+        3_000,
+        2_000,
+    );
+    client.set_treasury_limits(&admin, &3_000, &4_000);
+
+    assert!(client
+        .try_withdraw_treasury(&admin, &TreasuryPool::Reserve, &2_500)
+        .is_ok());
+
+    assert_savings_error(
+        client
+            .try_withdraw_treasury(&admin, &TreasuryPool::Rewards, &1_600)
+            .unwrap_err(),
+        SavingsError::AmountExceedsLimit,
+    );
+}
+
+#[test]
+fn test_daily_withdrawal_cap_resets_after_24_hours() {
+    let (env, contract_id, client, admin) = setup();
+    env.mock_all_auths();
+
+    seed_and_allocate(
+        &env,
+        &contract_id,
+        &client,
+        &admin,
+        30_000,
+        5_000,
+        3_000,
+        2_000,
+    );
+    client.set_treasury_limits(&admin, &3_000, &4_000);
+
+    assert!(client
+        .try_withdraw_treasury(&admin, &TreasuryPool::Reserve, &3_000)
+        .is_ok());
+    assert_savings_error(
+        client
+            .try_withdraw_treasury(&admin, &TreasuryPool::Rewards, &1_100)
+            .unwrap_err(),
+        SavingsError::AmountExceedsLimit,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += 24 * 60 * 60 + 1;
+    });
+
+    assert!(client
+        .try_withdraw_treasury(&admin, &TreasuryPool::Rewards, &3_000)
+        .is_ok());
+}
+
+#[test]
+fn test_treasury_withdrawal_validates_pool_balance() {
+    let (env, contract_id, client, admin) = setup();
+    env.mock_all_auths();
+
+    seed_and_allocate(
+        &env,
+        &contract_id,
+        &client,
+        &admin,
+        10_000,
+        4_000,
+        4_000,
+        2_000,
+    );
+    client.set_treasury_limits(&admin, &10_000, &20_000);
+
+    assert_savings_error(
+        client
+            .try_withdraw_treasury(&admin, &TreasuryPool::Operations, &2_001)
+            .unwrap_err(),
+        SavingsError::InsufficientBalance,
+    );
+}
+
+#[test]
+fn test_non_admin_cannot_update_limits_or_withdraw() {
+    let (env, contract_id, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    seed_and_allocate(
+        &env,
+        &contract_id,
+        &client,
+        &admin,
+        15_000,
+        5_000,
+        3_000,
+        2_000,
+    );
+
+    assert_savings_error(
+        client
+            .try_set_treasury_limits(&non_admin, &1_000, &3_000)
+            .unwrap_err(),
+        SavingsError::Unauthorized,
+    );
+    assert_savings_error(
+        client
+            .try_withdraw_treasury(&non_admin, &TreasuryPool::Reserve, &500)
+            .unwrap_err(),
+        SavingsError::Unauthorized,
+    );
+}

--- a/contracts/src/treasury/types.rs
+++ b/contracts/src/treasury/types.rs
@@ -12,6 +12,15 @@ pub struct Treasury {
     pub operations_balance: i128,
 }
 
+/// Defines which treasury sub-balance is used during withdrawal.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TreasuryPool {
+    Reserve,
+    Rewards,
+    Operations,
+}
+
 impl Default for Treasury {
     fn default() -> Self {
         Self::new()
@@ -27,6 +36,41 @@ impl Treasury {
             treasury_balance: 0,
             rewards_balance: 0,
             operations_balance: 0,
+        }
+    }
+}
+
+/// Withdrawal safety limits used to protect treasury funds.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TreasurySecurityConfig {
+    pub max_withdrawal_per_tx: i128,
+    pub daily_withdrawal_cap: i128,
+}
+
+impl TreasurySecurityConfig {
+    pub fn default_limits() -> Self {
+        Self {
+            // Conservative defaults; admin can tune via set_treasury_limits.
+            max_withdrawal_per_tx: 10_000_000,
+            daily_withdrawal_cap: 50_000_000,
+        }
+    }
+}
+
+/// Tracks daily withdrawal usage for treasury operations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TreasuryDailyWithdrawal {
+    pub window_start_ts: u64,
+    pub withdrawn_amount: i128,
+}
+
+impl TreasuryDailyWithdrawal {
+    pub fn new(window_start_ts: u64) -> Self {
+        Self {
+            window_start_ts,
+            withdrawn_amount: 0,
         }
     }
 }

--- a/contracts/test_snapshots/config_tests/test_full_config_lifecycle.1.json
+++ b/contracts/test_snapshots/config_tests/test_full_config_lifecycle.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 250
+                },
+                {
+                  "u32": 250
+                },
+                {
+                  "u32": 250
                 }
               ]
             }
@@ -84,10 +90,16 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee",
+              "function_name": "set_fees",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 500
+                },
+                {
+                  "u32": 500
                 },
                 {
                   "u32": 500
@@ -127,10 +139,16 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee",
+              "function_name": "set_fees",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 300
+                },
+                {
+                  "u32": 300
                 },
                 {
                   "u32": 300
@@ -217,6 +235,206 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -276,6 +494,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 300
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -288,7 +518,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -300,12 +530,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 300
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_get_config_reflects_updates.1.json
+++ b/contracts/test_snapshots/config_tests/test_get_config_reflects_updates.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -82,10 +88,16 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee",
+              "function_name": "set_fees",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 500
+                },
+                {
+                  "u32": 500
                 },
                 {
                   "u32": 500
@@ -152,6 +164,206 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -211,6 +423,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -223,7 +447,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -235,12 +459,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_initialize_config_max_fee.1.json
+++ b/contracts/test_snapshots/config_tests/test_initialize_config_max_fee.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 10000
+                },
+                {
+                  "u32": 10000
+                },
+                {
+                  "u32": 10000
                 }
               ]
             }
@@ -102,6 +108,206 @@
             "ext": "v0"
           },
           3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -167,6 +373,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 10000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -179,7 +397,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -191,12 +409,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 10000
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_initialize_config_succeeds.1.json
+++ b/contracts/test_snapshots/config_tests/test_initialize_config_succeeds.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -102,6 +108,206 @@
             "ext": "v0"
           },
           3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -167,6 +373,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -179,7 +397,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -191,12 +409,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_initialize_config_zero_fee.1.json
+++ b/contracts/test_snapshots/config_tests/test_initialize_config_zero_fee.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 0
+                },
+                {
+                  "u32": 0
+                },
+                {
+                  "u32": 0
                 }
               ]
             }
@@ -102,6 +108,206 @@
             "ext": "v0"
           },
           3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -167,6 +373,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -179,7 +397,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -191,12 +409,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_non_admin_cannot_set_protocol_fee.1.json
+++ b/contracts/test_snapshots/config_tests/test_non_admin_cannot_set_protocol_fee.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -102,6 +108,206 @@
             "ext": "v0"
           },
           3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -167,6 +373,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -179,7 +397,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -191,12 +409,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_non_admin_cannot_set_treasury.1.json
+++ b/contracts/test_snapshots/config_tests/test_non_admin_cannot_set_treasury.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -102,6 +108,206 @@
             "ext": "v0"
           },
           3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -167,6 +373,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -179,7 +397,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -191,12 +409,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_reinitialize_config_fails.1.json
+++ b/contracts/test_snapshots/config_tests/test_reinitialize_config_fails.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -102,6 +108,206 @@
             "ext": "v0"
           },
           3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -167,6 +373,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -179,7 +397,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -191,12 +409,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_set_protocol_fee_exceeds_max.1.json
+++ b/contracts/test_snapshots/config_tests/test_set_protocol_fee_exceeds_max.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -102,6 +108,206 @@
             "ext": "v0"
           },
           3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -167,6 +373,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -179,7 +397,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -191,12 +409,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_set_protocol_fee_succeeds.1.json
+++ b/contracts/test_snapshots/config_tests/test_set_protocol_fee_succeeds.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -60,10 +66,16 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee",
+              "function_name": "set_fees",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 500
+                },
+                {
+                  "u32": 500
                 },
                 {
                   "u32": 500
@@ -130,6 +142,206 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -189,6 +401,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -201,7 +425,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -213,12 +437,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_set_protocol_fee_to_max.1.json
+++ b/contracts/test_snapshots/config_tests/test_set_protocol_fee_to_max.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -60,10 +66,16 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee",
+              "function_name": "set_fees",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 10000
+                },
+                {
+                  "u32": 10000
                 },
                 {
                   "u32": 10000
@@ -129,6 +141,206 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -188,6 +400,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 10000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -200,7 +424,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -212,12 +436,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 10000
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_set_protocol_fee_to_zero.1.json
+++ b/contracts/test_snapshots/config_tests/test_set_protocol_fee_to_zero.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -60,10 +66,16 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee",
+              "function_name": "set_fees",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 0
+                },
+                {
+                  "u32": 0
                 },
                 {
                   "u32": 0
@@ -130,6 +142,206 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -189,6 +401,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -201,7 +425,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -213,12 +437,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
                         }
                       }
                     ]

--- a/contracts/test_snapshots/config_tests/test_set_treasury_succeeds.1.json
+++ b/contracts/test_snapshots/config_tests/test_set_treasury_succeeds.1.json
@@ -45,6 +45,12 @@
                 },
                 {
                   "u32": 100
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
                 }
               ]
             }
@@ -130,6 +136,206 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryDailyWithdrawal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryDailyWithdrawal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "window_start_ts"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "withdrawn_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasurySecurityConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasurySecurityConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "daily_withdrawal_cap"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_withdrawal_per_tx"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -189,6 +395,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Initialized"
                             }
                           ]
@@ -201,7 +419,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "ProtocolFeeBps"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -213,12 +431,24 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Treasury"
+                              "symbol": "TreasuryAddress"
                             }
                           ]
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/flexi/tests/test_flexi_deposit_with_protocol_fee.1.json
+++ b/contracts/test_snapshots/flexi/tests/test_flexi_deposit_with_protocol_fee.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 500
+                },
+                {
+                  "u32": 500
+                },
                 {
                   "u32": 500
                 }
@@ -241,6 +250,94 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "500"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "500"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "500"
+                      }
+                    }
+                  ]
                 }
               }
             },
@@ -456,6 +553,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -480,7 +589,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -498,6 +607,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
                         }
                       }
                     ]

--- a/contracts/test_snapshots/flexi/tests/test_flexi_fee_rounds_down.1.json
+++ b/contracts/test_snapshots/flexi/tests/test_flexi_fee_rounds_down.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 125
+                },
+                {
+                  "u32": 125
+                },
                 {
                   "u32": 125
                 }
@@ -241,6 +250,94 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "41"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "41"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "41"
+                      }
+                    }
+                  ]
                 }
               }
             },
@@ -456,6 +553,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 125
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -480,7 +589,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -498,6 +607,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 125
                         }
                       }
                     ]

--- a/contracts/test_snapshots/flexi/tests/test_flexi_small_amount_edge_case.1.json
+++ b/contracts/test_snapshots/flexi/tests/test_flexi_small_amount_edge_case.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
+                },
                 {
                   "u32": 100
                 }
@@ -411,6 +420,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -435,7 +456,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -453,6 +474,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/flexi/tests/test_flexi_withdraw_with_protocol_fee.1.json
+++ b/contracts/test_snapshots/flexi/tests/test_flexi_withdraw_with_protocol_fee.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 250
+                },
+                {
+                  "u32": 250
+                },
                 {
                   "u32": 250
                 }
@@ -264,6 +273,94 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "350"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "350"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "350"
+                      }
+                    }
+                  ]
                 }
               }
             },
@@ -479,6 +576,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 250
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -503,7 +612,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -521,6 +630,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 250
                         }
                       }
                     ]

--- a/contracts/test_snapshots/goal/tests/test_break_unauthorized_fails.1.json
+++ b/contracts/test_snapshots/goal/tests/test_break_unauthorized_fails.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -13,10 +13,13 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "initialize_user",
+              "function_name": "initialize",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
                 }
               ]
             }
@@ -46,7 +49,26 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize_user",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -54,7 +76,7 @@
               "function_name": "create_goal_save",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "symbol": "other"
@@ -174,7 +196,7 @@
                         "symbol": "owner"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -248,10 +270,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "User"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "symbol": "Paused"
                 }
               ]
             },
@@ -268,33 +287,13 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "User"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "symbol": "Paused"
                     }
                   ]
                 },
                 "durability": "persistent",
                 "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "savings_count"
-                      },
-                      "val": {
-                        "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "total_balance"
-                      },
-                      "val": {
-                        "i128": "0"
-                      }
-                    }
-                  ]
+                  "bool": false
                 }
               }
             },
@@ -372,10 +371,72 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "User"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "User"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "savings_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "UserGoalSaves"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -395,7 +456,7 @@
                       "symbol": "UserGoalSaves"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -424,7 +485,7 @@
                   "symbol": "UserLedger"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -444,7 +505,7 @@
                       "symbol": "UserLedger"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -518,7 +579,7 @@
                   "symbol": "UserLedger"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -538,7 +599,7 @@
                       "symbol": "UserLedger"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -629,6 +690,42 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminPublicKey"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "ReentrancyGuard"
                             }
                           ]
@@ -644,7 +741,7 @@
             },
             "ext": "v0"
           },
-          4095
+          3110400
         ]
       ],
       [
@@ -683,10 +780,10 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "1033654523790656264"
+                "nonce": "4837995959683129791"
               }
             },
             "durability": "temporary"
@@ -698,10 +795,10 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "1033654523790656264"
+                    "nonce": "4837995959683129791"
                   }
                 },
                 "durability": "temporary",
@@ -748,6 +845,39 @@
       ],
       [
         {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -764,7 +894,7 @@
             },
             "ext": "v0"
           },
-          4095
+          3110400
         ]
       ]
     ]

--- a/contracts/test_snapshots/goal/tests/test_goal_create_with_protocol_fee.1.json
+++ b/contracts/test_snapshots/goal/tests/test_goal_create_with_protocol_fee.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 500
+                },
+                {
+                  "u32": 500
+                },
                 {
                   "u32": 500
                 }
@@ -374,6 +383,94 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "250"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "250"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "User"
                 },
                 {
@@ -623,6 +720,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -647,7 +756,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -665,6 +774,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
                         }
                       }
                     ]

--- a/contracts/test_snapshots/goal/tests/test_goal_deposit_with_protocol_fee.1.json
+++ b/contracts/test_snapshots/goal/tests/test_goal_deposit_with_protocol_fee.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 300
+                },
+                {
+                  "u32": 300
+                },
                 {
                   "u32": 300
                 }
@@ -400,6 +409,94 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "150"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "150"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "User"
                 },
                 {
@@ -649,6 +746,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 300
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -673,7 +782,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -691,6 +800,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 300
                         }
                       }
                     ]

--- a/contracts/test_snapshots/goal/tests/test_goal_fee_calculation_correctness.1.json
+++ b/contracts/test_snapshots/goal/tests/test_goal_fee_calculation_correctness.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u32": 1000
+                },
                 {
                   "u32": 1000
                 }
@@ -374,6 +383,94 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "User"
                 },
                 {
@@ -623,6 +720,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -647,7 +756,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -665,6 +774,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1000
                         }
                       }
                     ]

--- a/contracts/test_snapshots/goal/tests/test_goal_small_amount_fee_edge_case.1.json
+++ b/contracts/test_snapshots/goal/tests/test_goal_small_amount_fee_edge_case.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 100
+                },
+                {
+                  "u32": 100
+                },
                 {
                   "u32": 100
                 }
@@ -578,6 +587,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -602,7 +623,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -620,6 +641,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
                         }
                       }
                     ]

--- a/contracts/test_snapshots/goal/tests/test_goal_withdraw_with_protocol_fee.1.json
+++ b/contracts/test_snapshots/goal/tests/test_goal_withdraw_with_protocol_fee.1.json
@@ -73,8 +73,17 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_protocol_fee_bps",
+              "function_name": "set_fees",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 250
+                },
+                {
+                  "u32": 250
+                },
                 {
                   "u32": 250
                 }
@@ -397,6 +406,94 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "operations_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reserve_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_balance"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_fees_collected"
+                      },
+                      "val": {
+                        "i128": "246"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_yield_earned"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "treasury_balance"
+                      },
+                      "val": {
+                        "i128": "246"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "User"
                 },
                 {
@@ -646,6 +743,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "DepositFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 250
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeRecipient"
                             }
                           ]
@@ -670,7 +779,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "PlatformFee"
+                              "symbol": "PerformanceFeeBps"
                             }
                           ]
                         },
@@ -688,6 +797,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "WithdrawalFeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 250
                         }
                       }
                     ]


### PR DESCRIPTION
Closes #364 

Introduce admin-controlled per-transaction and daily treasury withdrawal limits with strict pool-balance and invariant validation to block abuse paths. Expose new treasury limit and withdrawal entry points and add focused failure tests so exploit-prevention behavior is locked by CI.

Made-with: Cursor