### PR TITLE
feat: configure strict stellar validation pipes and decorators

### DIFF
--- a/backend/src/common/validators/is-stellar-key.validator.spec.ts
+++ b/backend/src/common/validators/is-stellar-key.validator.spec.ts
@@ -1,0 +1,49 @@
+import { validate } from 'class-validator';
+import { IsStellarPublicKey } from './is-stellar-key.validator';
+
+class TestDto {
+  @IsStellarPublicKey()
+  publicKey: string;
+}
+
+describe('IsStellarPublicKey', () => {
+  it('accepts valid 56-char Stellar public keys starting with G', async () => {
+    const dto = new TestDto();
+    dto.publicKey = `G${'A'.repeat(55)}`;
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects keys with invalid prefix', async () => {
+    const dto = new TestDto();
+    dto.publicKey = `S${'A'.repeat(55)}`;
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects keys shorter than 56 chars', async () => {
+    const dto = new TestDto();
+    dto.publicKey = `G${'A'.repeat(54)}`;
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects keys longer than 56 chars', async () => {
+    const dto = new TestDto();
+    dto.publicKey = `G${'A'.repeat(56)}`;
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects non-base32 characters', async () => {
+    const dto = new TestDto();
+    dto.publicKey = `G${'A'.repeat(54)}!`;
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/common/validators/is-stellar-key.validator.ts
+++ b/backend/src/common/validators/is-stellar-key.validator.ts
@@ -28,7 +28,7 @@ export function IsStellarPublicKey(validationOptions?: ValidationOptions) {
           }
 
           // Stellar public keys: start with G, exactly 56 chars, Base32 (A-Z, 2-7)
-          const stellarKeyPattern = /^G[A-Z2-7]{54}$/;
+          const stellarKeyPattern = /^G[A-Z2-7]{55}$/;
           return stellarKeyPattern.test(value);
         },
         defaultMessage(args: ValidationArguments) {
@@ -63,7 +63,7 @@ export function IsSorobanContractId(validationOptions?: ValidationOptions) {
           }
 
           // Soroban contract IDs: start with C, exactly 56 chars, Base32 (A-Z, 2-7)
-          const sorobanContractPattern = /^C[A-Z2-7]{54}$/;
+          const sorobanContractPattern = /^C[A-Z2-7]{55}$/;
           return sorobanContractPattern.test(value);
         },
         defaultMessage(args: ValidationArguments) {

--- a/backend/src/modules/savings/dto/subscribe.dto.ts
+++ b/backend/src/modules/savings/dto/subscribe.dto.ts
@@ -1,5 +1,6 @@
-import { IsUUID, IsNumber, Min } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID, IsNumber, Min, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsStellarPublicKey } from '../../../common/validators/is-stellar-key.validator';
 
 export class SubscribeDto {
   @ApiProperty({ description: 'Savings product ID to subscribe to' })
@@ -10,4 +11,12 @@ export class SubscribeDto {
   @IsNumber()
   @Min(0.01)
   amount: number;
+
+  @ApiPropertyOptional({
+    example: 'GABCDEF234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHJKLMN',
+    description: 'Optional Stellar wallet address associated with this subscription',
+  })
+  @IsOptional()
+  @IsStellarPublicKey()
+  walletAddress?: string;
 }


### PR DESCRIPTION
- enforce Stellar key regex as ^G[A-Z2-7]{55}$ for 56-char Ed25519 public keys
- align Soroban contract regex length to 56-char format consistency
- apply IsStellarPublicKey to SubscribeDto.walletAddress (optional field)
- keep strict global ValidationPipe (whitelist + forbidNonWhitelisted)
- add focused validator unit tests for valid/invalid key cases

Closes #393