### PR TITLE
feat(frontend): add Terms of Service and Privacy Policy pages (#609, …

### DIFF
--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -1,26 +1,26 @@
-'use client';
+"use client";
 
-import React from 'react';
+import React from "react";
 
 const productLinks = [
-  { label: 'Flexible Savings', href: '#' },
-  { label: 'Locked Savings', href: '#' },
-  { label: 'Goal Fund', href: '#' },
-  { label: 'Group Savings', href: '#' },
+  { label: "Flexible Savings", href: "#" },
+  { label: "Locked Savings", href: "#" },
+  { label: "Goal Fund", href: "#" },
+  { label: "Group Savings", href: "#" },
 ];
 
 const companyLinks = [
-  { label: 'About', href: '#' },
-  { label: 'Blog', href: '#' },
-  { label: 'Careers', href: '#' },
-  { label: 'Press', href: '#' },
+  { label: "About", href: "#" },
+  { label: "Blog", href: "#" },
+  { label: "Careers", href: "#" },
+  { label: "Press", href: "#" },
 ];
 
 const communityLinks = [
-  { label: 'Discord', href: 'https://discord.gg/nestera' },
-  { label: 'Telegram', href: 'https://t.me/nestera' },
-  { label: 'Twitter', href: '#' },
-  { label: 'GitHub', href: 'https://github.com/nestera' },
+  { label: "Discord", href: "https://discord.gg/nestera" },
+  { label: "Telegram", href: "https://t.me/nestera" },
+  { label: "Twitter", href: "#" },
+  { label: "GitHub", href: "https://github.com/nestera" },
 ];
 
 const Footer: React.FC = () => {
@@ -47,9 +47,29 @@ const Footer: React.FC = () => {
                 className="flex items-center justify-center shrink-0 text-[#00d4c0]"
                 aria-hidden="true"
               >
-                <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <rect x="4" y="8" width="24" height="16" rx="3" stroke="currentColor" strokeWidth="2" fill="none" />
-                  <path d="M4 14h24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                <svg
+                  width="32"
+                  height="32"
+                  viewBox="0 0 32 32"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    x="4"
+                    y="8"
+                    width="24"
+                    height="16"
+                    rx="3"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    fill="none"
+                  />
+                  <path
+                    d="M4 14h24"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
                   <circle cx="10" cy="11" r="1.5" fill="currentColor" />
                 </svg>
               </span>
@@ -60,7 +80,10 @@ const Footer: React.FC = () => {
             </p>
           </div>
 
-          <nav className="flex flex-wrap gap-12 max-md:flex-col max-md:gap-7" aria-label="Footer navigation">
+          <nav
+            className="flex flex-wrap gap-12 max-md:flex-col max-md:gap-7"
+            aria-label="Footer navigation"
+          >
             <div className="min-w-[120px] max-md:min-w-0">
               <h3 className="text-[0.85rem] font-bold text-white normal-case tracking-normal mb-4 leading-tight">
                 Product
@@ -128,12 +151,32 @@ const Footer: React.FC = () => {
             </p>
             <div className="flex items-center gap-4">
               <a
+                href="/terms"
+                className="text-xs font-normal text-[rgba(180,210,210,0.65)] no-underline transition-colors duration-200 hover:text-[#00d4c0] focus-visible:outline-2 focus-visible:outline-[#00d4c0] focus-visible:outline-offset-2 rounded-sm"
+              >
+                Terms of Service
+              </a>
+              <a
+                href="/privacy"
+                className="text-xs font-normal text-[rgba(180,210,210,0.65)] no-underline transition-colors duration-200 hover:text-[#00d4c0] focus-visible:outline-2 focus-visible:outline-[#00d4c0] focus-visible:outline-offset-2 rounded-sm"
+              >
+                Privacy Policy
+              </a>
+            </div>
+            <div className="flex items-center gap-4">
+              <a
                 href="#"
                 className="inline-flex items-center justify-center text-white/80 transition-all duration-200 hover:text-[#00d4c0] hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-[#00d4c0] focus-visible:outline-offset-2 rounded"
                 aria-label="Twitter"
                 title="Twitter"
               >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
                   <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
                 </svg>
               </a>
@@ -143,7 +186,13 @@ const Footer: React.FC = () => {
                 aria-label="Discord"
                 title="Discord"
               >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
                   <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
                 </svg>
               </a>
@@ -153,8 +202,18 @@ const Footer: React.FC = () => {
                 aria-label="GitHub"
                 title="GitHub"
               >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                  <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.415 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                    d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.415 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"
+                  />
                 </svg>
               </a>
             </div>

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,0 +1,249 @@
+import type { Metadata } from "next";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Nestera",
+  description: "Privacy Policy for Nestera - Decentralized Savings on Stellar",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-[#061a1a]">
+      <Navbar />
+      <div className="container mx-auto px-4 py-16 max-w-4xl">
+        <h1 className="text-4xl font-bold text-white mb-8">Privacy Policy</h1>
+
+        <div className="prose prose-invert max-w-none">
+          <p className="text-gray-300 mb-8">
+            Last updated:{" "}
+            {new Date().toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </p>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              1. Introduction
+            </h2>
+            <p className="text-gray-300 mb-4">
+              Nestera ("we", "us", or "our") respects your privacy and is
+              committed to protecting your personal data. This privacy policy
+              explains how we collect, use, disclose, and safeguard your
+              information when you use our decentralized savings platform.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              2. Information We Collect
+            </h2>
+            <p className="text-gray-300 mb-4">
+              As a decentralized platform, we minimize data collection. We may
+              collect:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>
+                <strong>Wallet Addresses:</strong> Public blockchain addresses
+                associated with your account
+              </li>
+              <li>
+                <strong>Transaction Data:</strong> Public transaction history on
+                the Stellar blockchain
+              </li>
+              <li>
+                <strong>Usage Analytics:</strong> Anonymous usage patterns and
+                feature interactions
+              </li>
+              <li>
+                <strong>Device Information:</strong> Browser type, operating
+                system, and screen resolution
+              </li>
+              <li>
+                <strong>Communication Data:</strong> Messages sent through our
+                support channels
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              3. How We Use Your Information
+            </h2>
+            <p className="text-gray-300 mb-4">
+              We use collected information to:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>Provide and maintain our decentralized savings services</li>
+              <li>Process transactions and manage your savings goals</li>
+              <li>Improve platform functionality and user experience</li>
+              <li>Ensure security and prevent fraudulent activities</li>
+              <li>Comply with legal obligations and regulatory requirements</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              4. Data Protection and Security
+            </h2>
+            <p className="text-gray-300 mb-4">
+              We implement robust security measures to protect your data:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>End-to-end encryption for data transmission</li>
+              <li>Secure server infrastructure with regular security audits</li>
+              <li>Access controls and authentication mechanisms</li>
+              <li>Regular security updates and vulnerability assessments</li>
+              <li>Incident response procedures for data breaches</li>
+            </ul>
+            <p className="text-gray-300 mb-4">
+              However, as a decentralized platform, the security of your funds
+              ultimately depends on your wallet security practices.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              5. Cookie Policy
+            </h2>
+            <p className="text-gray-300 mb-4">
+              We use cookies and similar technologies to enhance your
+              experience:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>
+                <strong>Essential Cookies:</strong> Required for basic platform
+                functionality
+              </li>
+              <li>
+                <strong>Analytics Cookies:</strong> Help us understand how users
+                interact with our platform
+              </li>
+              <li>
+                <strong>Preference Cookies:</strong> Remember your settings and
+                preferences
+              </li>
+            </ul>
+            <p className="text-gray-300 mb-4">
+              You can control cookie settings through your browser preferences.
+              Disabling certain cookies may affect platform functionality.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              6. Data Sharing and Disclosure
+            </h2>
+            <p className="text-gray-300 mb-4">
+              We do not sell, trade, or rent your personal information. We may
+              share information only in the following circumstances:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>With your explicit consent</li>
+              <li>To comply with legal obligations or court orders</li>
+              <li>To prevent fraud, security threats, or illegal activities</li>
+              <li>
+                With service providers who assist our operations (under strict
+                confidentiality agreements)
+              </li>
+              <li>In connection with a business transfer or acquisition</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              7. Your Rights
+            </h2>
+            <p className="text-gray-300 mb-4">
+              Depending on your location, you may have the following rights
+              regarding your personal data:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>
+                <strong>Access:</strong> Request a copy of the personal data we
+                hold about you
+              </li>
+              <li>
+                <strong>Rectification:</strong> Correct inaccurate or incomplete
+                data
+              </li>
+              <li>
+                <strong>Erasure:</strong> Request deletion of your personal data
+                (subject to legal requirements)
+              </li>
+              <li>
+                <strong>Portability:</strong> Receive your data in a structured,
+                machine-readable format
+              </li>
+              <li>
+                <strong>Restriction:</strong> Limit how we process your data
+              </li>
+              <li>
+                <strong>Objection:</strong> Object to certain types of data
+                processing
+              </li>
+            </ul>
+            <p className="text-gray-300 mb-4">
+              To exercise these rights, please contact us at
+              privacy@nestera.com.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              8. International Data Transfers
+            </h2>
+            <p className="text-gray-300 mb-4">
+              As a global decentralized platform, your data may be transferred
+              to and processed in countries other than your own. We ensure
+              appropriate safeguards are in place to protect your data during
+              such transfers.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              9. Children's Privacy
+            </h2>
+            <p className="text-gray-300 mb-4">
+              Our service is not intended for children under 18 years of age. We
+              do not knowingly collect personal information from children under
+              18. If we become aware that we have collected personal data from a
+              child under 18, we will take steps to delete such information.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              10. Changes to This Privacy Policy
+            </h2>
+            <p className="text-gray-300 mb-4">
+              We may update this privacy policy from time to time. We will
+              notify users of material changes through our platform or via
+              email. Your continued use of Nestera after such modifications
+              constitutes acceptance of the updated policy.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              11. Contact Us
+            </h2>
+            <p className="text-gray-300 mb-4">
+              If you have any questions about this Privacy Policy or our data
+              practices, please contact us at:
+            </p>
+            <p className="text-gray-300 mb-4">
+              Email: privacy@nestera.com
+              <br />
+              Address: [Company Address]
+            </p>
+          </section>
+        </div>
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from "next";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — Nestera",
+  description:
+    "Terms of Service for Nestera - Decentralized Savings on Stellar",
+};
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-[#061a1a]">
+      <Navbar />
+      <div className="container mx-auto px-4 py-16 max-w-4xl">
+        <h1 className="text-4xl font-bold text-white mb-8">Terms of Service</h1>
+
+        <div className="prose prose-invert max-w-none">
+          <p className="text-gray-300 mb-8">
+            Last updated:{" "}
+            {new Date().toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </p>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              1. Acceptance of Terms
+            </h2>
+            <p className="text-gray-300 mb-4">
+              By accessing and using Nestera ("the Service"), you accept and
+              agree to be bound by the terms and provision of this agreement. If
+              you do not agree to abide by the above, please do not use this
+              service.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              2. Description of Service
+            </h2>
+            <p className="text-gray-300 mb-4">
+              Nestera is a decentralized savings platform built on the Stellar
+              blockchain. Our service allows users to create and manage savings
+              goals, earn yield through smart contracts, and participate in
+              decentralized finance activities.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              3. User Agreements
+            </h2>
+            <p className="text-gray-300 mb-4">
+              By using Nestera, you agree to:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>
+                Provide accurate and complete information when creating an
+                account
+              </li>
+              <li>Maintain the security of your wallet and private keys</li>
+              <li>
+                Use the service in compliance with applicable laws and
+                regulations
+              </li>
+              <li>Not engage in any fraudulent or illegal activities</li>
+              <li>
+                Accept responsibility for all transactions initiated through
+                your account
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              4. Service Limitations
+            </h2>
+            <p className="text-gray-300 mb-4">
+              Nestera provides the service "as is" and "as available". We do not
+              guarantee:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>Uninterrupted or error-free operation of the service</li>
+              <li>Specific yields or returns on savings</li>
+              <li>Compatibility with all wallets or browsers</li>
+              <li>
+                Protection against all security threats or vulnerabilities
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              5. Blockchain and Smart Contract Risks
+            </h2>
+            <p className="text-gray-300 mb-4">
+              As a decentralized platform, Nestera operates on blockchain
+              technology. Users acknowledge and accept:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>Risks associated with cryptocurrency volatility</li>
+              <li>Potential smart contract vulnerabilities</li>
+              <li>Network congestion or delays on the Stellar blockchain</li>
+              <li>Irreversible nature of blockchain transactions</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              6. Liability Disclaimers
+            </h2>
+            <p className="text-gray-300 mb-4">
+              To the maximum extent permitted by law, Nestera and its affiliates
+              shall not be liable for:
+            </p>
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-2">
+              <li>
+                Any direct, indirect, incidental, or consequential damages
+              </li>
+              <li>Loss of profits, data, or cryptocurrency</li>
+              <li>Service interruptions or technical failures</li>
+              <li>Third-party actions or external market conditions</li>
+            </ul>
+            <p className="text-gray-300 mb-4">
+              Users are solely responsible for their financial decisions and the
+              security of their funds.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              7. Termination
+            </h2>
+            <p className="text-gray-300 mb-4">
+              We reserve the right to terminate or suspend your account and
+              access to the service at our discretion, without prior notice, for
+              conduct that violates these terms or is harmful to other users or
+              the service.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              8. Governing Law
+            </h2>
+            <p className="text-gray-300 mb-4">
+              These terms shall be governed by and construed in accordance with
+              the laws of [Jurisdiction], without regard to its conflict of law
+              provisions.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              9. Changes to Terms
+            </h2>
+            <p className="text-gray-300 mb-4">
+              We reserve the right to modify these terms at any time. Users will
+              be notified of significant changes, and continued use of the
+              service constitutes acceptance of the modified terms.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-white mb-4">
+              10. Contact Information
+            </h2>
+            <p className="text-gray-300 mb-4">
+              If you have any questions about these Terms of Service, please
+              contact us at legal@nestera.com.
+            </p>
+          </section>
+        </div>
+      </div>
+      <Footer />
+    </main>
+  );
+}


### PR DESCRIPTION
…#610)

feat(frontend): add Terms of Service and Privacy Policy pages (#609, #610)

- Create /terms page
  - Include terms and conditions
  - Define user agreements
  - Outline service limitations
  - Add liability disclaimers

- Create /privacy page
  - Document data collection practices
  - Include cookie policy details
  - Explain user rights
  - Describe data protection measures

- Ensure pages are accessible and aligned with legal/compliance requirements (e.g., GDPR)

closes #609 
closes #610 