### PR TITLE
[721] Fix implicit any type error in WalletContext changes parameter

### DIFF
--- a/frontend/app/context/WalletContext.tsx
+++ b/frontend/app/context/WalletContext.tsx
@@ -17,6 +17,14 @@ import {
 } from "@stellar/freighter-api";
 import { Horizon } from "@stellar/stellar-sdk";
 
+/** Matches the CallbackParams shape from @stellar/freighter-api's WatchWalletChanges. */
+interface WalletChangeEvent {
+  address: string;
+  network: string;
+  networkPassphrase: string;
+  error?: unknown;
+}
+
 interface Balance {
   asset_code: string;
   balance: string;
@@ -202,7 +210,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       // Initialize watcher to poll every 3 seconds
       networkWatcher.current = new WatchWalletChanges(3000);
 
-      networkWatcher.current.watch((changes) => {
+      networkWatcher.current.watch((changes: WalletChangeEvent) => {
         if (changes.network && changes.network !== state.network) {
           setState((prevState) => ({
             ...prevState,


### PR DESCRIPTION
Closes #721

## Summary

Fixes the implicit `any` type error in `WalletContext.tsx` and documents the type shape for the freighter-api callback parameter.

## Changes

### `frontend/app/context/WalletContext.tsx`
- Added `WalletChangeEvent` interface that explicitly models the `CallbackParams` shape from `@stellar/freighter-api`'s `WatchWalletChanges` (fields: `address`, `network`, `networkPassphrase`, `error?`)
- Annotated the `WatchWalletChanges.watch` callback parameter at line 205 with the new `WalletChangeEvent` type — eliminating the implicit `any`

## Verification

```
npx tsc --noEmit
EXIT: 0
```

`strict: true` is enabled in `tsconfig.json`. No implicit `any` types remain.

Note: `@stellar/freighter-api` and `@stellar/stellar-sdk` both ship their own `.d.ts` declarations (confirmed in `node_modules/@stellar/freighter-api/build/` and `node_modules/@stellar/stellar-sdk/`), so no additional `@types/*` packages are needed.
