### PR TITLE
feat(db): add btree indexes for hot filters and joins

### DIFF
--- a/backend/docs/database-indexing.md
+++ b/backend/docs/database-indexing.md
@@ -1,0 +1,36 @@
+# Database indexing strategy
+
+This backend uses PostgreSQL with TypeORM. Migrations under `src/migrations/` are the source of truth for production schema; entity `@Index()` decorators keep the ORM model aligned with the database.
+
+## Principles
+
+1. **Foreign keys and ownership** — Index columns used in `WHERE` / `JOIN` for parent keys (for example `userId`, `proposalId`).
+2. **Filters and sorts** — Add composite indexes that match common predicates together (for example `(userId, status)` for “this user’s active subscriptions”).
+3. **Uniqueness** — Prefer `UNIQUE` constraints where appropriate; PostgreSQL builds a btree index for each constraint, so avoid duplicating a second index on the same column unless you have a measured need.
+4. **New entities** — When adding a table, add explicit indexes in the same migration that creates the table (or follow up immediately with a migration). Declare matching `@Index()` on the entity.
+5. **Naming** — Use lowercase `idx_<table>_<columns>` for non-unique indexes so migrations stay grep-friendly.
+
+## Issue #660 indexes
+
+| Area | Indexes |
+|------|---------|
+| `users` | `email`, `publicKey`, `walletAddress` — created only if no btree index already covers the column (unique constraints count). |
+| `user_subscriptions` | `(userId, status)`, `(productId, status)`, `(userId, productId)` |
+| `savings_goals` | `(userId, status)` in addition to existing single-column indexes from earlier migrations |
+| `transactions` | `(userId, status)`, `(userId, txHash)`, `(status)` |
+| `governance_proposals` | `(status)`, `(status, onChainId)` |
+| `votes` | `(proposalId, walletAddress)` for proposal-scoped queries; unique `(walletAddress, proposalId)` unchanged |
+
+## Verifying performance
+
+On a staging database with representative row counts:
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM user_subscriptions
+WHERE "userId" = $1 AND status = 'ACTIVE';
+```
+
+Compare plans before and after applying migration `AddFrequentQueryIndexes1775400000000`. Prefer index scans over sequential scans on large tables for these predicates.
+
+For production-sized tables, consider running heavy `CREATE INDEX` operations during a maintenance window; optionally use `CREATE INDEX CONCURRENTLY` outside a transaction (TypeORM’s default migration transaction must be disabled for that statement).

--- a/backend/src/migrations/1775400000000-AddFrequentQueryIndexes.ts
+++ b/backend/src/migrations/1775400000000-AddFrequentQueryIndexes.ts
@@ -1,0 +1,124 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds btree indexes for hot filters and joins (#660).
+ *
+ * For `users`, single-column indexes are created only when no btree index
+ * already references that column (UNIQUE constraints already provide one).
+ */
+export class AddFrequentQueryIndexes1775400000000 implements MigrationInterface {
+  name = 'AddFrequentQueryIndexes1775400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION _nestera_column_has_btree_index(
+        p_table regclass,
+        p_attname name
+      ) RETURNS boolean
+      LANGUAGE sql
+      STABLE
+      AS $fn$
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_index idx
+          JOIN pg_class tbl ON tbl.oid = idx.indrelid
+          CROSS JOIN LATERAL unnest(idx.indkey::smallint[]) AS attnums(attnum)
+          JOIN pg_attribute a ON a.attrelid = tbl.oid AND a.attnum = attnums.attnum
+          WHERE tbl.oid = p_table
+            AND idx.indisvalid
+            AND a.attnum > 0
+            AND NOT a.attisdropped
+            AND a.attname = p_attname
+        );
+      $fn$;
+    `);
+
+    await queryRunner.query(`
+      DO $body$
+      BEGIN
+        IF NOT _nestera_column_has_btree_index('public.users'::regclass, 'email') THEN
+          EXECUTE 'CREATE INDEX idx_users_email ON public.users (email)';
+        END IF;
+        IF NOT _nestera_column_has_btree_index('public.users'::regclass, 'publicKey') THEN
+          EXECUTE 'CREATE INDEX idx_users_public_key ON public.users ("publicKey")';
+        END IF;
+        IF NOT _nestera_column_has_btree_index('public.users'::regclass, 'walletAddress') THEN
+          EXECUTE 'CREATE INDEX idx_users_wallet_address ON public.users ("walletAddress")';
+        END IF;
+      END
+      $body$;
+    `);
+
+    await queryRunner.query(`
+      DROP FUNCTION IF EXISTS _nestera_column_has_btree_index(regclass, name);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_user_subscriptions_user_id_status
+        ON user_subscriptions ("userId", status);
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_user_subscriptions_product_id_status
+        ON user_subscriptions ("productId", status);
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_user_subscriptions_user_id_product_id
+        ON user_subscriptions ("userId", "productId");
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_savings_goals_user_id_status
+        ON savings_goals ("userId", status);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_transactions_user_id_status
+        ON transactions ("userId", status);
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_transactions_user_id_tx_hash
+        ON transactions ("userId", "txHash");
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_transactions_status
+        ON transactions (status);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_governance_proposals_status
+        ON governance_proposals (status);
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_governance_proposals_status_on_chain_id
+        ON governance_proposals (status, "onChainId");
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_votes_proposal_id_wallet_address
+        ON votes ("proposalId", "walletAddress");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_votes_proposal_id_wallet_address;`);
+
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS idx_governance_proposals_status_on_chain_id;`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_governance_proposals_status;`);
+
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_transactions_status;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_transactions_user_id_tx_hash;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_transactions_user_id_status;`);
+
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_savings_goals_user_id_status;`);
+
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_user_subscriptions_user_id_product_id;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_user_subscriptions_product_id_status;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_user_subscriptions_user_id_status;`);
+
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_users_wallet_address;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_users_public_key;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_users_email;`);
+  }
+}

--- a/backend/src/modules/governance/entities/governance-proposal.entity.ts
+++ b/backend/src/modules/governance/entities/governance-proposal.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  Index,
 } from 'typeorm';
 import { Vote } from './vote.entity';
 
@@ -23,6 +24,8 @@ export enum ProposalCategory {
 }
 
 @Entity('governance_proposals')
+@Index('idx_governance_proposals_status', ['status'])
+@Index('idx_governance_proposals_status_on_chain_id', ['status', 'onChainId'])
 export class GovernanceProposal {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/backend/src/modules/governance/entities/vote.entity.ts
+++ b/backend/src/modules/governance/entities/vote.entity.ts
@@ -15,7 +15,8 @@ export enum VoteDirection {
 }
 
 @Entity('votes')
-@Index(['walletAddress', 'proposal'], { unique: true })
+@Index(['walletAddress', 'proposalId'], { unique: true })
+@Index('idx_votes_proposal_id_wallet_address', ['proposalId', 'walletAddress'])
 export class Vote {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/backend/src/modules/savings/entities/savings-goal.entity.ts
+++ b/backend/src/modules/savings/entities/savings-goal.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 
@@ -62,6 +63,7 @@ export interface SavingsGoalMetadata {
  *    queries fast — callers opt-in via QueryBuilder or `relations` option.
  */
 @Entity('savings_goals')
+@Index('idx_savings_goals_user_id_status', ['userId', 'status'])
 export class SavingsGoal {
   // ── Primary key ─────────────────────────────────────────────────────────────
 

--- a/backend/src/modules/savings/entities/user-subscription.entity.ts
+++ b/backend/src/modules/savings/entities/user-subscription.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { SavingsProduct } from './savings-product.entity';
 
@@ -16,6 +17,9 @@ export enum SubscriptionStatus {
 }
 
 @Entity('user_subscriptions')
+@Index('idx_user_subscriptions_user_id_status', ['userId', 'status'])
+@Index('idx_user_subscriptions_product_id_status', ['productId', 'status'])
+@Index('idx_user_subscriptions_user_id_product_id', ['userId', 'productId'])
 export class UserSubscription {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/backend/src/modules/transactions/entities/transaction.entity.ts
+++ b/backend/src/modules/transactions/entities/transaction.entity.ts
@@ -26,6 +26,9 @@ export enum TxStatus {
 
 @Entity('transactions')
 @Unique(['txHash'])
+@Index('idx_transactions_user_id_status', ['userId', 'status'])
+@Index('idx_transactions_user_id_tx_hash', ['userId', 'txHash'])
+@Index('idx_transactions_status', ['status'])
 export class Transaction extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;


### PR DESCRIPTION
## Summary
Adds PostgreSQL btree indexes for the paths called out in #660: subscriptions, savings goals, ledger transactions, governance proposals, and votes. `users` lookup columns are indexed only when no btree index already covers them (so we do not duplicate indexes already created by `UNIQUE` constraints).

## Changes
- New migration `1775400000000-AddFrequentQueryIndexes.ts` with `CREATE INDEX IF NOT EXISTS` for all non-user tables and conditional index creation for `users.email`, `users.publicKey`, `users.walletAddress`.
- `@Index()` on entities so the ORM model matches the DB: `UserSubscription`, `SavingsGoal`, `Transaction`, `GovernanceProposal`, `Vote` (unique vote key now explicitly uses `proposalId`; adds `(proposalId, walletAddress)` for proposal-scoped reads).
- `backend/docs/database-indexing.md` — naming, when to index, how to validate with `EXPLAIN (ANALYZE, BUFFERS)`, note on `CONCURRENTLY` for very large tables.

## How to verify
- Run migrations against a staging DB with realistic volume, then compare `EXPLAIN ANALYZE` for representative queries (e.g. subscriptions by `userId` + `status`, transactions by `userId` + `status`).
- `pnpm run build` in `backend/` passes.

Closes #660