### PR TITLE
feat(db): configure TypeORM/pg connection pooling and read replica

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,15 @@ CONTRACT_ID=YOUR_DEPLOYED_CONTRACT_ID
 # Option A – URL-based (takes precedence; typical for cloud/container deployments)
 DATABASE_URL=postgresql://user:password@localhost:5432/nestera
 
+# Optional read replica (enables TypeORM replication; separate pg pool to this URL for SELECTs)
+# DATABASE_READ_URL=postgresql://user:password@replica-host:5432/nestera
+
+# pg pool tuning (applied per pool — primary and each replica each get their own pool with these limits)
+# DB_POOL_MAX=20
+# DB_POOL_MIN=2
+# DB_POOL_CONNECTION_TIMEOUT_MS=10000
+# DB_POOL_IDLE_TIMEOUT_MS=30000
+
 # Option B – Host-based (used when DATABASE_URL is absent; useful for Kubernetes secrets)
 # DB_HOST=localhost
 # DB_PORT=5432

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import * as Joi from 'joi';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import configuration from './config/configuration';
+import { createTypeOrmModuleOptions } from './config/typeorm-options.factory';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './modules/health/health.module';
@@ -41,6 +42,11 @@ const envValidationSchema = Joi.object({
   DB_USER: Joi.string().optional(),
   DB_PASS: Joi.string().optional(),
   DATABASE_URL: Joi.string().uri().optional(),
+  DATABASE_READ_URL: Joi.string().uri().optional(),
+  DB_POOL_MAX: Joi.number().integer().min(1).max(500).optional(),
+  DB_POOL_MIN: Joi.number().integer().min(0).max(200).optional(),
+  DB_POOL_CONNECTION_TIMEOUT_MS: Joi.number().integer().min(0).optional(),
+  DB_POOL_IDLE_TIMEOUT_MS: Joi.number().integer().min(0).optional(),
 
   JWT_SECRET: Joi.string().min(10).required(),
   JWT_EXPIRATION: Joi.string().required(),
@@ -114,38 +120,8 @@ const envValidationSchema = Joi.object({
     EventEmitterModule.forRoot(),
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        const dbUrl = configService.get<string>('database.url');
-        const dbHost = configService.get<string>('database.host');
-
-        if (dbUrl) {
-          // URL-based connection (e.g. DATABASE_URL on cloud platforms)
-          return {
-            type: 'postgres' as const,
-            url: dbUrl,
-            autoLoadEntities: true,
-            synchronize: configService.get<string>('NODE_ENV') !== 'production',
-          };
-        }
-
-        // Host-based connection (uses DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS)
-        if (!dbHost) {
-          throw new Error(
-            'Database configuration error: set either DATABASE_URL or DB_HOST in your environment.',
-          );
-        }
-
-        return {
-          type: 'postgres' as const,
-          host: dbHost,
-          port: configService.get<number>('database.port') ?? 5432,
-          database: configService.get<string>('database.name'),
-          username: configService.get<string>('database.user'),
-          password: configService.get<string>('database.pass'),
-          autoLoadEntities: true,
-          synchronize: configService.get<string>('NODE_ENV') !== 'production',
-        };
-      },
+      useFactory: (configService: ConfigService) =>
+        createTypeOrmModuleOptions(configService),
     }),
     AuthModule,
     RedisCacheModule,

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -3,12 +3,26 @@ export default () => ({
   database: {
     // URL-based connection (takes precedence when provided)
     url: process.env.DATABASE_URL,
+    // Optional read-replica URL; enables TypeORM replication (separate pool to replica)
+    readUrl: process.env.DATABASE_READ_URL,
     // Host-based connection (used when DATABASE_URL is absent)
     host: process.env.DB_HOST,
     port: parseInt(process.env.DB_PORT || '5432', 10),
     name: process.env.DB_NAME,
     user: process.env.DB_USER,
     pass: process.env.DB_PASS,
+    pool: {
+      max: parseInt(process.env.DB_POOL_MAX || '20', 10),
+      min: parseInt(process.env.DB_POOL_MIN || '2', 10),
+      connectionTimeoutMs: parseInt(
+        process.env.DB_POOL_CONNECTION_TIMEOUT_MS || '10000',
+        10,
+      ),
+      idleTimeoutMs: parseInt(
+        process.env.DB_POOL_IDLE_TIMEOUT_MS || '30000',
+        10,
+      ),
+    },
   },
   jwt: {
     secret: process.env.JWT_SECRET,

--- a/backend/src/config/connection-pool.config.ts
+++ b/backend/src/config/connection-pool.config.ts
@@ -1,0 +1,90 @@
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Sensible defaults for a single NestJS API instance talking to PostgreSQL via `pg`.
+ * Tune `DB_POOL_*` after load testing (connections × replicas × pods vs. `max_connections` on the server).
+ */
+export const DB_POOL_DEFAULT_MAX = 20;
+export const DB_POOL_DEFAULT_MIN = 2;
+export const DB_POOL_DEFAULT_CONNECTION_TIMEOUT_MS = 10_000;
+export const DB_POOL_DEFAULT_IDLE_TIMEOUT_MS = 30_000;
+
+export interface DbPoolSettings {
+  max: number;
+  min: number;
+  connectionTimeoutMillis: number;
+  idleTimeoutMillis: number;
+}
+
+export function resolveDbPoolSettingsFromEnv(
+  env: NodeJS.ProcessEnv,
+): DbPoolSettings {
+  const num = (key: string, fallback: number) => {
+    const raw = env[key];
+    if (raw === undefined || raw === '') {
+      return fallback;
+    }
+    const v = parseInt(raw, 10);
+    return Number.isFinite(v) ? v : fallback;
+  };
+  return {
+    max: num('DB_POOL_MAX', DB_POOL_DEFAULT_MAX),
+    min: num('DB_POOL_MIN', DB_POOL_DEFAULT_MIN),
+    connectionTimeoutMillis: num(
+      'DB_POOL_CONNECTION_TIMEOUT_MS',
+      DB_POOL_DEFAULT_CONNECTION_TIMEOUT_MS,
+    ),
+    idleTimeoutMillis: num(
+      'DB_POOL_IDLE_TIMEOUT_MS',
+      DB_POOL_DEFAULT_IDLE_TIMEOUT_MS,
+    ),
+  };
+}
+
+export function resolveDbPoolSettingsFromConfig(
+  config: ConfigService,
+): DbPoolSettings {
+  return {
+    max: config.get<number>('database.pool.max') ?? DB_POOL_DEFAULT_MAX,
+    min: config.get<number>('database.pool.min') ?? DB_POOL_DEFAULT_MIN,
+    connectionTimeoutMillis:
+      config.get<number>('database.pool.connectionTimeoutMs') ??
+      DB_POOL_DEFAULT_CONNECTION_TIMEOUT_MS,
+    idleTimeoutMillis:
+      config.get<number>('database.pool.idleTimeoutMs') ??
+      DB_POOL_DEFAULT_IDLE_TIMEOUT_MS,
+  };
+}
+
+/**
+ * Passed to node-postgres Pool via TypeORM `extra` (merged in {@link PostgresDriver.createPool}).
+ */
+export function buildTypeOrmPgExtra(
+  settings: DbPoolSettings,
+): Record<string, unknown> {
+  return {
+    max: settings.max,
+    min: settings.min,
+    connectionTimeoutMillis: settings.connectionTimeoutMillis,
+    idleTimeoutMillis: settings.idleTimeoutMillis,
+    allowExitOnIdle: false,
+  };
+}
+
+export interface PgPoolMetricsSnapshot {
+  totalCount: number;
+  idleCount: number;
+  waitingCount: number;
+}
+
+export function snapshotPgPool(pool: {
+  totalCount: number;
+  idleCount: number;
+  waitingCount: number;
+}): PgPoolMetricsSnapshot {
+  return {
+    totalCount: pool.totalCount,
+    idleCount: pool.idleCount,
+    waitingCount: pool.waitingCount,
+  };
+}

--- a/backend/src/config/typeorm-options.factory.ts
+++ b/backend/src/config/typeorm-options.factory.ts
@@ -1,0 +1,75 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import {
+  buildTypeOrmPgExtra,
+  resolveDbPoolSettingsFromConfig,
+} from './connection-pool.config';
+
+/**
+ * Builds Nest `TypeOrmModule` options including pg pool sizing, timeouts, and optional read replica routing.
+ *
+ * When `database.readUrl` (`DATABASE_READ_URL`) is set, TypeORM replication is enabled: writes use the primary,
+ * SELECT-heavy workloads use the replica pool (separate `pg.Pool` instances in the driver).
+ */
+export function createTypeOrmModuleOptions(
+  configService: ConfigService,
+): TypeOrmModuleOptions {
+  const logger = new Logger('TypeOrmPool');
+  const nodeEnv = configService.get<string>('NODE_ENV');
+  const dbUrl = configService.get<string>('database.url');
+  const readUrl = configService.get<string | undefined>('database.readUrl');
+  const poolSettings = resolveDbPoolSettingsFromConfig(configService);
+  const extra = buildTypeOrmPgExtra(poolSettings);
+
+  const base: TypeOrmModuleOptions = {
+    type: 'postgres',
+    autoLoadEntities: true,
+    synchronize: nodeEnv !== 'production',
+    connectTimeoutMS: poolSettings.connectionTimeoutMillis,
+    extra,
+    poolErrorHandler: (err: Error) => {
+      logger.error(err.message, err.stack);
+    },
+  };
+
+  if (dbUrl) {
+    if (readUrl) {
+      return {
+        ...base,
+        replication: {
+          master: { url: dbUrl },
+          slaves: [{ url: readUrl }],
+        },
+      };
+    }
+    return { ...base, url: dbUrl };
+  }
+
+  const dbHost = configService.get<string>('database.host');
+  if (!dbHost) {
+    throw new Error(
+      'Database configuration error: set either DATABASE_URL or DB_HOST in your environment.',
+    );
+  }
+
+  const hostOptions = {
+    host: dbHost,
+    port: configService.get<number>('database.port') ?? 5432,
+    database: configService.get<string>('database.name'),
+    username: configService.get<string>('database.user'),
+    password: configService.get<string>('database.pass'),
+  };
+
+  if (readUrl) {
+    return {
+      ...base,
+      replication: {
+        master: hostOptions,
+        slaves: [{ url: readUrl }],
+      },
+    };
+  }
+
+  return { ...base, ...hostOptions };
+}

--- a/backend/src/config/typeorm.config.ts
+++ b/backend/src/config/typeorm.config.ts
@@ -1,7 +1,13 @@
 import { DataSource } from 'typeorm';
 import * as dotenv from 'dotenv';
+import {
+  buildTypeOrmPgExtra,
+  resolveDbPoolSettingsFromEnv,
+} from './connection-pool.config';
 
 dotenv.config();
+
+const pool = resolveDbPoolSettingsFromEnv(process.env);
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
@@ -11,6 +17,8 @@ export const AppDataSource = new DataSource({
   database: process.env.DB_NAME,
   username: process.env.DB_USER,
   password: process.env.DB_PASS,
+  connectTimeoutMS: pool.connectionTimeoutMillis,
+  extra: buildTypeOrmPgExtra(pool),
   entities: ['src/modules/**/entities/*.entity.ts'],
   migrations: ['src/migrations/*.ts'],
   synchronize: false,

--- a/backend/src/modules/health/indicators/typeorm.health.ts
+++ b/backend/src/modules/health/indicators/typeorm.health.ts
@@ -5,10 +5,21 @@ import {
   HealthCheckError,
 } from '@nestjs/terminus';
 import { DataSource } from 'typeorm';
+import { snapshotPgPool } from '../../../config/connection-pool.config';
+
+type PgDriverLike = {
+  isReplicated?: boolean;
+  master?: { totalCount: number; idleCount: number; waitingCount: number };
+  slaves?: Array<{
+    totalCount: number;
+    idleCount: number;
+    waitingCount: number;
+  }>;
+};
 
 /**
- * Custom TypeORM Health Indicator
- * Ensures database connectivity and query performance within acceptable bounds (~200ms)
+ * TypeORM + PostgreSQL health: verifies primary connectivity, optionally checks a read replica,
+ * and surfaces `pg` pool queue metrics for monitoring.
  */
 @Injectable()
 export class TypeOrmHealthIndicator extends HealthIndicator {
@@ -17,33 +28,64 @@ export class TypeOrmHealthIndicator extends HealthIndicator {
   }
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
-    const startTime = Date.now();
+    const driver = this.dataSource.driver as PgDriverLike;
+    const pools: Record<string, unknown> = {};
+
+    if (driver.master) {
+      pools.master = snapshotPgPool(driver.master);
+    }
+    if (driver.slaves?.length) {
+      pools.replicas = driver.slaves.map((s) => snapshotPgPool(s));
+    }
+
+    const overallStart = Date.now();
 
     try {
-      // Execute a simple query to verify database connectivity
-      await this.dataSource.query('SELECT 1');
+      const masterStart = Date.now();
+      const masterRunner = this.dataSource.createQueryRunner('master');
+      try {
+        await masterRunner.query('SELECT 1');
+      } finally {
+        await masterRunner.release();
+      }
+      const masterResponseTime = Date.now() - masterStart;
 
-      const responseTime = Date.now() - startTime;
-      const isWithinBounds = responseTime <= 200; // ~200ms threshold
+      let replicaCheck: 'skipped' | 'ok' = 'skipped';
+      if (driver.isReplicated && driver.slaves?.length) {
+        const replicaRunner = this.dataSource.createQueryRunner('slave');
+        try {
+          await replicaRunner.query('SELECT 1');
+          replicaCheck = 'ok';
+        } finally {
+          await replicaRunner.release();
+        }
+      }
+
+      const totalElapsed = Date.now() - overallStart;
+      const isWithinBounds = masterResponseTime <= 200;
 
       const result = this.getStatus(key, isWithinBounds, {
-        responseTime: `${responseTime}ms`,
+        responseTime: `${masterResponseTime}ms`,
+        totalElapsed: `${totalElapsed}ms`,
         threshold: '200ms',
+        pools,
+        replicaCheck,
       });
 
       if (!isWithinBounds) {
         throw new HealthCheckError(
-          `Database query exceeded acceptable response time (${responseTime}ms > 200ms)`,
+          `Database primary query exceeded acceptable response time (${masterResponseTime}ms > 200ms)`,
           result,
         );
       }
 
       return result;
     } catch (error) {
-      const responseTime = Date.now() - startTime;
+      const totalElapsed = Date.now() - overallStart;
       const result = this.getStatus(key, false, {
         message: error instanceof Error ? error.message : 'Unknown error',
-        responseTime: `${responseTime}ms`,
+        totalElapsed: `${totalElapsed}ms`,
+        pools,
       });
 
       throw new HealthCheckError('Database health check failed', result);


### PR DESCRIPTION
## Summary
Implements production-oriented PostgreSQL pooling for Nest + TypeORM: explicit `pg` pool limits and timeouts, optional read replica via TypeORM replication (separate pools), structured pool error logging, and pool queue metrics on the database health check.

## Configuration
| Variable | Role |
|----------|------|
| `DATABASE_READ_URL` | Optional; if set, enables replication (writes → primary, reads routed per TypeORM replication rules). |
| `DB_POOL_MAX` / `DB_POOL_MIN` | Per-pool `pg` connection bounds (default 20 / 2). |
| `DB_POOL_CONNECTION_TIMEOUT_MS` | Initial connection timeout (default 10000). |
| `DB_POOL_IDLE_TIMEOUT_MS` | Idle client reaping (default 30000). |

## Health
- Primary: `SELECT 1` via `createQueryRunner('master')`.
- Replica: same on `'slave'` when replication is configured.
- Response includes `pools.master` / `pools.replicas` with `totalCount`, `idleCount`, `waitingCount`.

## Limitations
TypeORM applies the same `extra` pool options to every pool in replication mode; separate writer/reader **sizes** would need another approach (e.g. second DataSource).

Closes #661