### PR TITLE
feat: add ChartControls component for customizable chart settings

### DIFF
--- a/frontend/app/dashboard/analytics/AnalyticsComparisonGrid.tsx
+++ b/frontend/app/dashboard/analytics/AnalyticsComparisonGrid.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import {
   Bar,
   BarChart,
+  Brush,
   CartesianGrid,
   ComposedChart,
   Legend,
@@ -14,11 +15,27 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { ArrowUpRight, Goal, Layers3, TrendingUp } from "lucide-react";
+import {
+  ArrowUpRight,
+  BarChart2,
+  Download,
+  Eye,
+  EyeOff,
+  Goal,
+  Layers3,
+  LineChart as LineIcon,
+  Maximize2,
+  Minimize2,
+  Palette,
+  TrendingUp,
+} from "lucide-react";
 import { useTheme } from "../../context/ThemeContext";
+import { colorSchemes } from "./useChartPreferences";
+import type { ColorScheme } from "./useChartPreferences";
+
+// ── Types ──────────────────────────────────────────────────────────────────
 
 type TooltipRecord = Record<string, number | string>;
-
 type TooltipPayloadItem = {
   color?: string;
   dataKey?: string | number;
@@ -30,6 +47,7 @@ type TooltipPayloadItem = {
 type ChartPalette = {
   accent: string;
   accentAlt: string;
+  accentSoft: string;
   success: string;
   violet: string;
   text: string;
@@ -38,6 +56,17 @@ type ChartPalette = {
   tooltipBg: string;
   tooltipBorder: string;
 };
+
+type CardChartType = "bar" | "line";
+
+type RenderProps = {
+  showLegend: boolean;
+  chartType: CardChartType;
+  palette: ChartPalette;
+  showBrush: boolean;
+};
+
+// ── Static data ────────────────────────────────────────────────────────────
 
 const monthComparisonData = [
   { metric: "Deposits", previous: 28.4, current: 32.6 },
@@ -74,12 +103,12 @@ const poolPerformanceData = [
   { pool: "Yield Basket", apy: 9.6, yield30d: 2.4, tvl: 1.38 },
 ];
 
-const paletteByTheme: Record<"light" | "dark", ChartPalette> = {
+// ── Base theme (non-color-scheme values) ───────────────────────────────────
+
+type BaseTheme = Pick<ChartPalette, "text" | "muted" | "grid" | "tooltipBg" | "tooltipBorder">;
+
+const baseThemeByMode: Record<"light" | "dark", BaseTheme> = {
   light: {
-    accent: "#0891b2",
-    accentAlt: "#2563eb",
-    success: "#059669",
-    violet: "#7c3aed",
     text: "#0f1f2a",
     muted: "#4a7080",
     grid: "rgba(74, 112, 128, 0.12)",
@@ -87,10 +116,6 @@ const paletteByTheme: Record<"light" | "dark", ChartPalette> = {
     tooltipBorder: "rgba(8, 145, 178, 0.18)",
   },
   dark: {
-    accent: "#00c9c8",
-    accentAlt: "#60a5fa",
-    success: "#34d399",
-    violet: "#a78bfa",
     text: "#f8fdff",
     muted: "#6e9ba2",
     grid: "rgba(94, 140, 150, 0.12)",
@@ -99,10 +124,27 @@ const paletteByTheme: Record<"light" | "dark", ChartPalette> = {
   },
 };
 
-export default function AnalyticsComparisonGrid() {
-  const { resolvedTheme } = useTheme();
-  const palette = useMemo(() => paletteByTheme[resolvedTheme], [resolvedTheme]);
+const COLOR_SCHEME_OPTIONS: { value: ColorScheme; label: string; swatch: string }[] = [
+  { value: "default", label: "Teal",   swatch: "#0891b2" },
+  { value: "ocean",   label: "Ocean",  swatch: "#1d4ed8" },
+  { value: "sunset",  label: "Sunset", swatch: "#ea580c" },
+  { value: "forest",  label: "Forest", swatch: "#16a34a" },
+];
 
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Grid ───────────────────────────────────────────────────────────────────
+
+export default function AnalyticsComparisonGrid() {
   return (
     <div className="mt-6 grid grid-cols-1 gap-6 2xl:grid-cols-2">
       <ComparisonCard
@@ -111,20 +153,35 @@ export default function AnalyticsComparisonGrid() {
         badge="+14.8% vs last month"
         summary="Deposits, yield, and portfolio value all accelerated month over month."
         icon={<TrendingUp size={18} />}
+        csvData={monthComparisonData}
+        csvFilename="month-comparison.csv"
+        supportedTypes={["bar", "line"]}
       >
-        <div className="h-[280px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
+        {({ showLegend, chartType, palette, showBrush }) =>
+          chartType === "line" ? (
+            <LineChart data={monthComparisonData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+              <CartesianGrid stroke={palette.grid} vertical={false} />
+              <XAxis dataKey="metric" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
+              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `${v}k`} />
+              <Tooltip content={<ComparisonTooltip palette={palette} valueSuffix="k" />} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="metric" height={18} stroke={palette.grid} />}
+              <Line type="monotone" dataKey="previous" name="Previous month" stroke={palette.accentAlt} strokeWidth={2.5} dot={{ r: 4, fill: palette.accentAlt }} activeDot={{ r: 5 }} />
+              <Line type="monotone" dataKey="current" name="Current month" stroke={palette.accent} strokeWidth={2.5} dot={{ r: 4, fill: palette.accent }} activeDot={{ r: 5 }} />
+            </LineChart>
+          ) : (
             <BarChart data={monthComparisonData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
               <CartesianGrid stroke={palette.grid} vertical={false} />
               <XAxis dataKey="metric" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
-              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(value: number) => `${value}k`} />
+              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `${v}k`} />
               <Tooltip content={<ComparisonTooltip palette={palette} valueSuffix="k" />} cursor={{ fill: palette.grid, opacity: 0.15 }} />
-              <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="metric" height={18} stroke={palette.grid} />}
               <Bar dataKey="previous" name="Previous month" fill={palette.accentAlt} radius={[8, 8, 0, 0]} maxBarSize={36} />
               <Bar dataKey="current" name="Current month" fill={palette.accent} radius={[8, 8, 0, 0]} maxBarSize={36} />
             </BarChart>
-          </ResponsiveContainer>
-        </div>
+          )
+        }
       </ComparisonCard>
 
       <ComparisonCard
@@ -133,20 +190,35 @@ export default function AnalyticsComparisonGrid() {
         badge="+$25k ahead of last year"
         summary="This year has outperformed last year in every month, widening the gap since Q2."
         icon={<ArrowUpRight size={18} />}
+        csvData={yearComparisonData}
+        csvFilename="year-comparison.csv"
+        supportedTypes={["line", "bar"]}
       >
-        <div className="h-[280px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
+        {({ showLegend, chartType, palette, showBrush }) =>
+          chartType === "bar" ? (
+            <BarChart data={yearComparisonData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+              <CartesianGrid stroke={palette.grid} vertical={false} />
+              <XAxis dataKey="month" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
+              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `$${v}k`} />
+              <Tooltip content={<ComparisonTooltip palette={palette} valuePrefix="$" valueSuffix="k" />} cursor={{ fill: palette.grid, opacity: 0.15 }} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="month" height={18} stroke={palette.grid} />}
+              <Bar dataKey="lastYear" name="Last year" fill={palette.violet} radius={[8, 8, 0, 0]} maxBarSize={18} />
+              <Bar dataKey="thisYear" name="This year" fill={palette.accent} radius={[8, 8, 0, 0]} maxBarSize={18} />
+            </BarChart>
+          ) : (
             <LineChart data={yearComparisonData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
               <CartesianGrid stroke={palette.grid} vertical={false} />
               <XAxis dataKey="month" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
-              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(value: number) => `$${value}k`} />
+              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `$${v}k`} />
               <Tooltip content={<ComparisonTooltip palette={palette} valuePrefix="$" valueSuffix="k" />} />
-              <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="month" height={18} stroke={palette.grid} />}
               <Line type="monotone" dataKey="lastYear" name="Last year" stroke={palette.violet} strokeWidth={2.5} dot={false} activeDot={{ r: 5, fill: palette.violet }} />
               <Line type="monotone" dataKey="thisYear" name="This year" stroke={palette.accent} strokeWidth={2.5} dot={false} activeDot={{ r: 5, fill: palette.accent }} />
             </LineChart>
-          </ResponsiveContainer>
-        </div>
+          )
+        }
       </ComparisonCard>
 
       <ComparisonCard
@@ -155,20 +227,35 @@ export default function AnalyticsComparisonGrid() {
         badge="3 of 4 goals ahead"
         summary="Emergency, travel, and retirement goals are pacing ahead of schedule this cycle."
         icon={<Goal size={18} />}
+        csvData={goalPerformanceData}
+        csvFilename="goal-comparison.csv"
+        supportedTypes={["bar", "line"]}
       >
-        <div className="h-[280px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
+        {({ showLegend, chartType, palette, showBrush }) =>
+          chartType === "line" ? (
+            <LineChart data={goalPerformanceData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+              <CartesianGrid stroke={palette.grid} vertical={false} />
+              <XAxis dataKey="goal" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
+              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `${v}%`} domain={[0, 100]} />
+              <Tooltip content={<ComparisonTooltip palette={palette} valueSuffix="%" />} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="goal" height={18} stroke={palette.grid} />}
+              <Line type="monotone" dataKey="target" name="Target" stroke={palette.accentAlt} strokeWidth={2.5} dot={{ r: 4, fill: palette.accentAlt }} activeDot={{ r: 5 }} />
+              <Line type="monotone" dataKey="actual" name="Actual" stroke={palette.success} strokeWidth={2.5} dot={{ r: 4, fill: palette.success }} activeDot={{ r: 5 }} />
+            </LineChart>
+          ) : (
             <BarChart data={goalPerformanceData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
               <CartesianGrid stroke={palette.grid} vertical={false} />
               <XAxis dataKey="goal" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
-              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(value: number) => `${value}%`} domain={[0, 100]} />
+              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `${v}%`} domain={[0, 100]} />
               <Tooltip content={<ComparisonTooltip palette={palette} valueSuffix="%" />} cursor={{ fill: palette.grid, opacity: 0.15 }} />
-              <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="goal" height={18} stroke={palette.grid} />}
               <Bar dataKey="target" name="Target" fill={palette.accentAlt} radius={[8, 8, 0, 0]} maxBarSize={30} />
               <Bar dataKey="actual" name="Actual" fill={palette.success} radius={[8, 8, 0, 0]} maxBarSize={30} />
             </BarChart>
-          </ResponsiveContainer>
-        </div>
+          )
+        }
       </ComparisonCard>
 
       <ComparisonCard
@@ -177,26 +264,44 @@ export default function AnalyticsComparisonGrid() {
         badge="XLM Vault leads yield"
         summary="XLM Vault continues to deliver the strongest yield profile with the highest TVL."
         icon={<Layers3 size={18} />}
+        csvData={poolPerformanceData}
+        csvFilename="pool-comparison.csv"
+        supportedTypes={["bar", "line"]}
       >
-        <div className="h-[280px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
+        {({ showLegend, chartType, palette, showBrush }) =>
+          chartType === "line" ? (
+            <LineChart data={poolPerformanceData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+              <CartesianGrid stroke={palette.grid} vertical={false} />
+              <XAxis dataKey="pool" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
+              <YAxis tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
+              <Tooltip content={<ComparisonTooltip palette={palette} />} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="pool" height={18} stroke={palette.grid} />}
+              <Line type="monotone" dataKey="apy" name="APY" stroke={palette.accent} strokeWidth={2.5} dot={{ r: 4, fill: palette.accent }} activeDot={{ r: 5 }} />
+              <Line type="monotone" dataKey="yield30d" name="30d Yield" stroke={palette.success} strokeWidth={2.5} dot={{ r: 4, fill: palette.success }} activeDot={{ r: 5 }} />
+              <Line type="monotone" dataKey="tvl" name="TVL" stroke={palette.violet} strokeWidth={2.5} dot={{ r: 4, fill: palette.violet }} activeDot={{ r: 5 }} />
+            </LineChart>
+          ) : (
             <ComposedChart data={poolPerformanceData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
               <CartesianGrid stroke={palette.grid} vertical={false} />
               <XAxis dataKey="pool" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} />
-              <YAxis yAxisId="left" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(value: number) => `${value}%`} />
-              <YAxis yAxisId="right" orientation="right" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(value: number) => `$${value}m`} />
+              <YAxis yAxisId="left" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `${v}%`} />
+              <YAxis yAxisId="right" orientation="right" tickLine={false} axisLine={false} tick={{ fill: palette.muted, fontSize: 12 }} tickFormatter={(v: number) => `$${v}m`} />
               <Tooltip content={<ComparisonTooltip palette={palette} />} />
-              <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />
+              {showLegend && <Legend wrapperStyle={{ color: palette.muted, fontSize: 12 }} />}
+              {showBrush && <Brush dataKey="pool" height={18} stroke={palette.grid} />}
               <Bar yAxisId="left" dataKey="apy" name="APY" fill={palette.accent} radius={[8, 8, 0, 0]} maxBarSize={28} />
               <Bar yAxisId="left" dataKey="yield30d" name="30d Yield" fill={palette.success} radius={[8, 8, 0, 0]} maxBarSize={28} />
               <Line yAxisId="right" type="monotone" dataKey="tvl" name="TVL" stroke={palette.violet} strokeWidth={2.5} dot={{ r: 4, fill: palette.violet }} activeDot={{ r: 5, fill: palette.violet }} />
             </ComposedChart>
-          </ResponsiveContainer>
-        </div>
+          )
+        }
       </ComparisonCard>
     </div>
   );
 }
+
+// ── ComparisonCard ─────────────────────────────────────────────────────────
 
 function ComparisonCard({
   title,
@@ -205,45 +310,232 @@ function ComparisonCard({
   summary,
   icon,
   children,
+  csvData,
+  csvFilename,
+  supportedTypes,
 }: {
   title: string;
   description: string;
   badge: string;
   summary: string;
   icon: React.ReactNode;
-  children: React.ReactNode;
+  children: (props: RenderProps) => React.ReactNode;
+  csvData: Record<string, unknown>[];
+  csvFilename: string;
+  supportedTypes: CardChartType[];
 }) {
+  const { resolvedTheme } = useTheme();
+  const [showLegend, setShowLegend] = useState(true);
+  const [showBrush, setShowBrush] = useState(false);
+  const [chartType, setChartType] = useState<CardChartType>(supportedTypes[0]);
+  const [colorScheme, setColorScheme] = useState<ColorScheme>("default");
+  const [exportOpen, setExportOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const exportRef = useRef<HTMLDivElement>(null);
+  const paletteRef = useRef<HTMLDivElement>(null);
+
+  const palette = useMemo((): ChartPalette => ({
+    ...baseThemeByMode[resolvedTheme],
+    ...colorSchemes[colorScheme][resolvedTheme],
+  }), [resolvedTheme, colorScheme]);
+
+  React.useEffect(() => {
+    if (!exportOpen && !paletteOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (exportOpen && !exportRef.current?.contains(e.target as Node)) setExportOpen(false);
+      if (paletteOpen && !paletteRef.current?.contains(e.target as Node)) setPaletteOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [exportOpen, paletteOpen]);
+
+  const handleExportSvg = useCallback(() => {
+    const svg = containerRef.current?.querySelector("svg");
+    if (!svg) return;
+    downloadBlob(new Blob([new XMLSerializer().serializeToString(svg)], { type: "image/svg+xml" }), csvFilename.replace(".csv", ".svg"));
+    setExportOpen(false);
+  }, [csvFilename]);
+
+  const handleExportPng = useCallback(() => {
+    const svg = containerRef.current?.querySelector("svg");
+    if (!svg) return;
+    const svgData = new XMLSerializer().serializeToString(svg);
+    const canvas = document.createElement("canvas");
+    const rect = svg.getBoundingClientRect();
+    canvas.width = rect.width * 2;
+    canvas.height = rect.height * 2;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.scale(2, 2);
+    const img = new Image();
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob((blob) => { if (blob) downloadBlob(blob, csvFilename.replace(".csv", ".png")); });
+    };
+    img.src = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgData)))}`;
+    setExportOpen(false);
+  }, [csvFilename]);
+
+  const handleExportCsv = useCallback(() => {
+    if (!csvData.length) return;
+    const keys = Object.keys(csvData[0]);
+    const rows = [keys.join(","), ...csvData.map((row) => keys.map((k) => row[k]).join(","))];
+    downloadBlob(new Blob([rows.join("\n")], { type: "text/csv" }), csvFilename);
+    setExportOpen(false);
+  }, [csvData, csvFilename]);
+
+  const iconBtn = (active: boolean) =>
+    `flex items-center justify-center rounded-lg p-1.5 transition-colors ${
+      active
+        ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+        : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
+    }`;
+
   return (
     <article className="rounded-2xl border border-[var(--color-border)] bg-linear-to-b from-[var(--color-card-start)] to-[var(--color-card-end)] p-6">
+      {/* Card header */}
       <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="flex items-center gap-3">
-            <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-accent)]">
-              {icon}
-            </span>
-            <div>
-              <h3 className="m-0 text-lg font-semibold text-[var(--color-text)]">{title}</h3>
-              <p className="mt-1 text-sm text-[var(--color-text-muted)]">{description}</p>
-            </div>
+        <div className="min-w-0 flex items-center gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-accent)]">
+            {icon}
+          </span>
+          <div>
+            <h3 className="m-0 text-lg font-semibold text-[var(--color-text)]">{title}</h3>
+            <p className="mt-1 text-sm text-[var(--color-text-muted)]">{description}</p>
           </div>
         </div>
-        <span className="rounded-full border border-[var(--color-border)] bg-[var(--color-accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--color-accent)]">
+        <span className="whitespace-nowrap rounded-full border border-[var(--color-border)] bg-[var(--color-accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--color-accent)]">
           {badge}
         </span>
       </div>
-      <div className="mt-5">{children}</div>
+
+      {/* Controls */}
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        {/* Chart type */}
+        <div className="flex items-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-1 gap-0.5">
+          {supportedTypes.map((t) => (
+            <button
+              key={t}
+              type="button"
+              aria-pressed={chartType === t}
+              onClick={() => setChartType(t)}
+              className={`flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs font-medium transition-colors ${
+                chartType === t
+                  ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                  : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+              }`}
+            >
+              {t === "line" ? <LineIcon size={12} /> : <BarChart2 size={12} />}
+              <span className="capitalize">{t}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Legend toggle */}
+        <button
+          type="button"
+          aria-pressed={showLegend}
+          aria-label="Toggle legend"
+          onClick={() => setShowLegend((v) => !v)}
+          className={iconBtn(showLegend)}
+          title="Toggle legend"
+        >
+          {showLegend ? <Eye size={14} /> : <EyeOff size={14} />}
+        </button>
+
+        {/* Zoom/brush toggle */}
+        <button
+          type="button"
+          aria-pressed={showBrush}
+          aria-label="Toggle zoom"
+          onClick={() => setShowBrush((v) => !v)}
+          className={iconBtn(showBrush)}
+          title="Zoom & pan"
+        >
+          {showBrush ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+        </button>
+
+        {/* Color scheme */}
+        <div ref={paletteRef} className="relative">
+          <button
+            type="button"
+            aria-expanded={paletteOpen}
+            aria-label="Color scheme"
+            onClick={() => setPaletteOpen((v) => !v)}
+            className={iconBtn(paletteOpen)}
+            title="Color scheme"
+          >
+            <Palette size={14} />
+          </button>
+          {paletteOpen && (
+            <div className="absolute left-0 top-full z-20 mt-2 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] p-2 shadow-xl">
+              <p className="mb-2 px-1 text-[10px] uppercase tracking-widest text-[var(--color-text-muted)]">Color scheme</p>
+              <div className="flex flex-col gap-1">
+                {COLOR_SCHEME_OPTIONS.map(({ value, label, swatch }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => { setColorScheme(value); setPaletteOpen(false); }}
+                    className={`flex items-center gap-2.5 rounded-xl px-3 py-2 text-sm transition-colors ${
+                      colorScheme === value
+                        ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                        : "text-[var(--color-text)] hover:bg-[var(--color-surface-subtle)]"
+                    }`}
+                  >
+                    <span className="h-3.5 w-3.5 shrink-0 rounded-full" style={{ background: swatch }} />
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Export */}
+        <div ref={exportRef} className="relative">
+          <button
+            type="button"
+            aria-expanded={exportOpen}
+            aria-label="Export"
+            onClick={() => setExportOpen((v) => !v)}
+            className={iconBtn(exportOpen)}
+            title="Export"
+          >
+            <Download size={14} />
+          </button>
+          {exportOpen && (
+            <div className="absolute left-0 top-full z-20 mt-2 min-w-[140px] rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] p-1.5 shadow-xl">
+              {[
+                { label: "Export PNG", action: handleExportPng },
+                { label: "Export SVG", action: handleExportSvg },
+                { label: "Export CSV", action: handleExportCsv },
+              ].map(({ label, action }) => (
+                <button key={label} type="button" onClick={action} className="flex w-full items-center rounded-xl px-3 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-surface-subtle)]">
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Chart */}
+      <div ref={containerRef} className="mt-4 w-full" style={{ height: showBrush ? 310 : 280 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          {children({ showLegend, chartType, palette, showBrush }) as React.ReactElement}
+        </ResponsiveContainer>
+      </div>
+
       <p className="mt-4 text-sm text-[var(--color-text-soft)]">{summary}</p>
     </article>
   );
 }
 
+// ── Tooltip ────────────────────────────────────────────────────────────────
+
 function ComparisonTooltip({
-  active,
-  payload,
-  label,
-  palette,
-  valuePrefix = "",
-  valueSuffix = "",
+  active, payload, label, palette, valuePrefix = "", valueSuffix = "",
 }: {
   active?: boolean;
   payload?: TooltipPayloadItem[];
@@ -252,32 +544,14 @@ function ComparisonTooltip({
   valuePrefix?: string;
   valueSuffix?: string;
 }) {
-  if (!active || !payload?.length) {
-    return null;
-  }
-
+  if (!active || !payload?.length) return null;
   return (
-    <div
-      style={{
-        background: palette.tooltipBg,
-        border: `1px solid ${palette.tooltipBorder}`,
-        borderRadius: 14,
-        padding: "12px 14px",
-        boxShadow: "0 18px 40px rgba(15,23,42,0.18)",
-      }}
-    >
+    <div style={{ background: palette.tooltipBg, border: `1px solid ${palette.tooltipBorder}`, borderRadius: 14, padding: "12px 14px", boxShadow: "0 18px 40px rgba(15,23,42,0.18)" }}>
       <p style={{ margin: 0, fontSize: 12, color: palette.muted, marginBottom: 8 }}>{label}</p>
       <div style={{ display: "grid", gap: 6 }}>
         {payload.map((item) => (
           <div key={String(item.dataKey ?? item.name)} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: 999,
-                background: item.color ?? palette.accent,
-              }}
-            />
+            <span style={{ width: 8, height: 8, borderRadius: 999, background: item.color ?? palette.accent, flexShrink: 0 }} />
             <span style={{ color: palette.text, fontSize: 13, fontWeight: 600 }}>
               {item.name}: {formatValue(item.value, item.dataKey, valuePrefix, valueSuffix)}
             </span>
@@ -288,27 +562,10 @@ function ComparisonTooltip({
   );
 }
 
-function formatValue(
-  value: number | string | undefined,
-  dataKey: string | number | undefined,
-  valuePrefix: string,
-  valueSuffix: string
-) {
-  if (typeof value !== "number") {
-    return value ?? "";
-  }
-
-  if (dataKey === "tvl") {
-    return `$${value.toFixed(2)}m`;
-  }
-
-  if (dataKey === "apy" || dataKey === "yield30d") {
-    return `${value}%`;
-  }
-
-  if (valuePrefix || valueSuffix) {
-    return `${valuePrefix}${value}${valueSuffix}`;
-  }
-
+function formatValue(value: number | string | undefined, dataKey: string | number | undefined, valuePrefix: string, valueSuffix: string) {
+  if (typeof value !== "number") return value ?? "";
+  if (dataKey === "tvl") return `$${value.toFixed(2)}m`;
+  if (dataKey === "apy" || dataKey === "yield30d") return `${value}%`;
+  if (valuePrefix || valueSuffix) return `${valuePrefix}${value}${valueSuffix}`;
   return value.toString();
 }

--- a/frontend/app/dashboard/analytics/ChartControls.tsx
+++ b/frontend/app/dashboard/analytics/ChartControls.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+import {
+  AreaChart as AreaIcon,
+  BarChart2,
+  Download,
+  Eye,
+  EyeOff,
+  GitCompare,
+  LineChart as LineIcon,
+  Maximize2,
+  Minimize2,
+  Palette,
+} from "lucide-react";
+import type { ChartType, ColorScheme, TimeRange } from "./useChartPreferences";
+
+const TIME_RANGES: TimeRange[] = ["7D", "30D", "90D", "1Y"];
+
+const CHART_TYPES: { value: ChartType; icon: React.ReactNode; label: string }[] = [
+  { value: "area", icon: <AreaIcon size={14} />, label: "Area" },
+  { value: "line", icon: <LineIcon size={14} />, label: "Line" },
+  { value: "bar", icon: <BarChart2 size={14} />, label: "Bar" },
+];
+
+const COLOR_SCHEMES: { value: ColorScheme; label: string; swatch: string }[] = [
+  { value: "default", label: "Teal",   swatch: "#0891b2" },
+  { value: "ocean",   label: "Ocean",  swatch: "#1d4ed8" },
+  { value: "sunset",  label: "Sunset", swatch: "#ea580c" },
+  { value: "forest",  label: "Forest", swatch: "#16a34a" },
+];
+
+type ChartControlsProps = {
+  chartType: ChartType;
+  timeRange: TimeRange;
+  colorScheme: ColorScheme;
+  showLegend: boolean;
+  showComparison: boolean;
+  showBrush: boolean;
+  onChartType: (v: ChartType) => void;
+  onTimeRange: (v: TimeRange) => void;
+  onColorScheme: (v: ColorScheme) => void;
+  onLegendToggle: () => void;
+  onComparisonToggle: () => void;
+  onBrushToggle: () => void;
+  onExportPng: () => void;
+  onExportSvg: () => void;
+  onExportCsv: () => void;
+};
+
+export default function ChartControls({
+  chartType,
+  timeRange,
+  colorScheme,
+  showLegend,
+  showComparison,
+  showBrush,
+  onChartType,
+  onTimeRange,
+  onColorScheme,
+  onLegendToggle,
+  onComparisonToggle,
+  onBrushToggle,
+  onExportPng,
+  onExportSvg,
+  onExportCsv,
+}: ChartControlsProps) {
+  const [exportOpen, setExportOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const exportRef = useRef<HTMLDivElement>(null);
+  const paletteRef = useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!exportOpen && !paletteOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (exportOpen && !exportRef.current?.contains(e.target as Node)) setExportOpen(false);
+      if (paletteOpen && !paletteRef.current?.contains(e.target as Node)) setPaletteOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [exportOpen, paletteOpen]);
+
+  const iconBtn = (active: boolean) =>
+    `flex items-center justify-center rounded-lg p-1.5 transition-colors ${
+      active
+        ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+        : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
+    }`;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {/* Chart type */}
+      <div className="flex items-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-1 gap-0.5">
+        {CHART_TYPES.map(({ value, icon, label }) => (
+          <button
+            key={value}
+            type="button"
+            aria-label={`${label} chart`}
+            aria-pressed={chartType === value}
+            onClick={() => onChartType(value)}
+            className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors ${
+              chartType === value
+                ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            }`}
+          >
+            {icon}
+            <span className="hidden sm:inline">{label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Time range */}
+      <div className="flex items-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-1 gap-0.5">
+        {TIME_RANGES.map((r) => (
+          <button
+            key={r}
+            type="button"
+            aria-pressed={timeRange === r}
+            onClick={() => onTimeRange(r)}
+            className={`rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors ${
+              timeRange === r
+                ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            }`}
+          >
+            {r}
+          </button>
+        ))}
+      </div>
+
+      {/* Legend toggle */}
+      <button
+        type="button"
+        aria-label="Toggle legend"
+        aria-pressed={showLegend}
+        onClick={onLegendToggle}
+        className={iconBtn(showLegend)}
+        title="Toggle legend"
+      >
+        {showLegend ? <Eye size={15} /> : <EyeOff size={15} />}
+      </button>
+
+      {/* Comparison toggle */}
+      <button
+        type="button"
+        aria-label="Toggle comparison mode"
+        aria-pressed={showComparison}
+        onClick={onComparisonToggle}
+        className={iconBtn(showComparison)}
+        title="Comparison mode"
+      >
+        <GitCompare size={15} />
+      </button>
+
+      {/* Brush/zoom toggle */}
+      <button
+        type="button"
+        aria-label="Toggle zoom"
+        aria-pressed={showBrush}
+        onClick={onBrushToggle}
+        className={iconBtn(showBrush)}
+        title="Zoom & pan"
+      >
+        {showBrush ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
+      </button>
+
+      {/* Color palette */}
+      <div ref={paletteRef} className="relative">
+        <button
+          type="button"
+          aria-label="Color scheme"
+          aria-expanded={paletteOpen}
+          onClick={() => setPaletteOpen((p) => !p)}
+          className={iconBtn(paletteOpen)}
+          title="Color scheme"
+        >
+          <Palette size={15} />
+        </button>
+        {paletteOpen && (
+          <div className="absolute right-0 top-full z-20 mt-2 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] p-2 shadow-xl">
+            <p className="mb-2 px-1 text-[10px] uppercase tracking-widest text-[var(--color-text-muted)]">
+              Color scheme
+            </p>
+            <div className="flex flex-col gap-1">
+              {COLOR_SCHEMES.map(({ value, label, swatch }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => { onColorScheme(value); setPaletteOpen(false); }}
+                  className={`flex items-center gap-2.5 rounded-xl px-3 py-2 text-sm transition-colors ${
+                    colorScheme === value
+                      ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                      : "text-[var(--color-text)] hover:bg-[var(--color-surface-subtle)]"
+                  }`}
+                >
+                  <span className="h-3.5 w-3.5 rounded-full flex-shrink-0" style={{ background: swatch }} />
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Export */}
+      <div ref={exportRef} className="relative">
+        <button
+          type="button"
+          aria-label="Export chart"
+          aria-expanded={exportOpen}
+          onClick={() => setExportOpen((p) => !p)}
+          className={iconBtn(exportOpen)}
+          title="Export"
+        >
+          <Download size={15} />
+        </button>
+        {exportOpen && (
+          <div className="absolute right-0 top-full z-20 mt-2 min-w-[140px] rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] p-1.5 shadow-xl">
+            {[
+              { label: "Export PNG", action: () => { onExportPng(); setExportOpen(false); } },
+              { label: "Export SVG", action: () => { onExportSvg(); setExportOpen(false); } },
+              { label: "Export CSV", action: () => { onExportCsv(); setExportOpen(false); } },
+            ].map(({ label, action }) => (
+              <button
+                key={label}
+                type="button"
+                onClick={action}
+                className="flex w-full items-center rounded-xl px-3 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-surface-subtle)]"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/analytics/PortfolioPerformanceChart.tsx
+++ b/frontend/app/dashboard/analytics/PortfolioPerformanceChart.tsx
@@ -1,135 +1,86 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import {
   Area,
   AreaChart,
+  Bar,
+  BarChart,
+  Brush,
   CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
-import { MoreHorizontal, TrendingUp } from "lucide-react";
+import { TrendingUp } from "lucide-react";
 import { useTheme } from "../../context/ThemeContext";
+import ChartControls from "./ChartControls";
+import { colorSchemes, useChartPreferences } from "./useChartPreferences";
+import type { ChartType, TimeRange } from "./useChartPreferences";
 
-const chartData = [
-  { date: "Aug 04", value: 105400 },
-  { date: "Aug 11", value: 106200 },
-  { date: "Aug 18", value: 107850 },
-  { date: "Aug 25", value: 108700 },
-  { date: "Sep 01", value: 110100 },
-  { date: "Sep 08", value: 111450 },
-  { date: "Sep 15", value: 113200 },
-  { date: "Sep 22", value: 114900 },
-  { date: "Sep 29", value: 116500 },
-  { date: "Oct 01", value: 118200 },
-  { date: "Oct 03", value: 119800 },
-  { date: "Oct 05", value: 119500 },
-  { date: "Oct 07", value: 120100 },
-  { date: "Oct 09", value: 119900 },
-  { date: "Oct 10", value: 120800 },
-  { date: "Oct 12", value: 121200 },
-  { date: "Oct 14", value: 120600 },
-  { date: "Oct 16", value: 121800 },
-  { date: "Oct 18", value: 122300 },
-  { date: "Oct 20", value: 123100 },
-  { date: "Oct 22", value: 123800 },
-  { date: "Oct 25", value: 124500 },
-  { date: "Oct 27", value: 124200 },
-  { date: "Oct 30", value: 124800 },
-  { date: "Nov 01", value: 124592 },
+const allChartData = [
+  { date: "Aug 04", value: 105400, prev: 98200 },
+  { date: "Aug 11", value: 106200, prev: 99100 },
+  { date: "Aug 18", value: 107850, prev: 100300 },
+  { date: "Aug 25", value: 108700, prev: 101200 },
+  { date: "Sep 01", value: 110100, prev: 102500 },
+  { date: "Sep 08", value: 111450, prev: 103800 },
+  { date: "Sep 15", value: 113200, prev: 104900 },
+  { date: "Sep 22", value: 114900, prev: 106100 },
+  { date: "Sep 29", value: 116500, prev: 107400 },
+  { date: "Oct 01", value: 118200, prev: 108700 },
+  { date: "Oct 03", value: 119800, prev: 109500 },
+  { date: "Oct 05", value: 119500, prev: 110200 },
+  { date: "Oct 07", value: 120100, prev: 110900 },
+  { date: "Oct 09", value: 119900, prev: 111400 },
+  { date: "Oct 10", value: 120800, prev: 112000 },
+  { date: "Oct 12", value: 121200, prev: 112600 },
+  { date: "Oct 14", value: 120600, prev: 113100 },
+  { date: "Oct 16", value: 121800, prev: 113700 },
+  { date: "Oct 18", value: 122300, prev: 114200 },
+  { date: "Oct 20", value: 123100, prev: 114800 },
+  { date: "Oct 22", value: 123800, prev: 115300 },
+  { date: "Oct 25", value: 124500, prev: 115900 },
+  { date: "Oct 27", value: 124200, prev: 116300 },
+  { date: "Oct 30", value: 124800, prev: 116800 },
+  { date: "Nov 01", value: 124592, prev: 117200 },
 ];
 
-const windowDataPointLimit: Record<string, number> = {
+const windowLimits: Record<TimeRange, number> = {
   "7D": 7,
   "30D": 16,
-  "90D": chartData.length,
+  "90D": 25,
+  "1Y": 25,
 };
 
-type TooltipPayloadItem = {
-  value: number;
-  payload: { date: string; value: number };
-};
-
-type ChartTheme = {
-  accent: string;
-  accentSoft: string;
-  background: string;
-  text: string;
-  muted: string;
-  grid: string;
-  tooltipBg: string;
-  tooltipBorder: string;
-};
-
-const chartThemeByResolvedTheme: Record<"light" | "dark", ChartTheme> = {
-  light: {
-    accent: "#0891b2",
-    accentSoft: "rgba(8, 145, 178, 0.18)",
-    background: "#ffffff",
-    text: "#0f1f2a",
-    muted: "#4a7080",
-    grid: "rgba(74, 112, 128, 0.12)",
-    tooltipBg: "rgba(255, 255, 255, 0.98)",
-    tooltipBorder: "rgba(8, 145, 178, 0.18)",
-  },
-  dark: {
-    accent: "#00c9c8",
-    accentSoft: "rgba(0, 201, 200, 0.18)",
-    background: "#081418",
-    text: "#ffffff",
-    muted: "#5e8c96",
-    grid: "rgba(94, 140, 150, 0.07)",
-    tooltipBg: "rgba(8, 20, 24, 0.95)",
-    tooltipBorder: "rgba(0, 201, 200, 0.3)",
-  },
-};
+type TooltipItem = { color?: string; dataKey?: string | number; name?: string; value?: number; payload: { date: string; value: number; prev?: number } };
 
 function CustomTooltip({
-  active,
-  payload,
-  theme,
+  active, payload, theme,
 }: {
   active?: boolean;
-  payload?: TooltipPayloadItem[];
-  theme: ChartTheme;
+  payload?: TooltipItem[];
+  theme: { tooltipBg: string; tooltipBorder: string; muted: string; text: string };
 }) {
   if (!active || !payload?.length) return null;
-
-  const { date, value } = payload[0].payload;
-
+  const date = payload[0].payload.date;
   return (
-    <div
-      style={{
-        background: theme.tooltipBg,
-        border: `1px solid ${theme.tooltipBorder}`,
-        borderRadius: 10,
-        padding: "10px 14px",
-        boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
-      }}
-    >
-      <p style={{ margin: 0, fontSize: 11, color: theme.muted, marginBottom: 4 }}>{date}, 2023</p>
-      <p style={{ margin: 0, fontSize: 16, fontWeight: 700, color: theme.text }}>
-        $
-        {value.toLocaleString("en-US", {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        })}
-      </p>
+    <div style={{ background: theme.tooltipBg, border: `1px solid ${theme.tooltipBorder}`, borderRadius: 10, padding: "10px 14px", boxShadow: "0 8px 32px rgba(0,0,0,0.18)" }}>
+      <p style={{ margin: 0, fontSize: 11, color: theme.muted, marginBottom: 6 }}>{date}, 2023</p>
+      {payload.map((item) => (
+        <p key={String(item.dataKey)} style={{ margin: "2px 0", fontSize: 14, fontWeight: 700, color: item.color ?? theme.text }}>
+          {item.name}: ${(item.value ?? 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+        </p>
+      ))}
     </div>
   );
 }
 
-function ActiveDot({
-  cx = 0,
-  cy = 0,
-  theme,
-}: {
-  cx?: number;
-  cy?: number;
-  theme: ChartTheme;
-}) {
+function ActiveDot({ cx = 0, cy = 0, theme }: { cx?: number; cy?: number; theme: { accentSoft: string; background: string; accent: string } }) {
   return (
     <g>
       <circle cx={cx} cy={cy} r={10} fill={theme.accentSoft} />
@@ -139,46 +90,138 @@ function ActiveDot({
   );
 }
 
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export default function PortfolioPerformanceChart() {
   const { resolvedTheme } = useTheme();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [selectedWindow, setSelectedWindow] = useState("30D");
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const chartTheme = useMemo(() => chartThemeByResolvedTheme[resolvedTheme], [resolvedTheme]);
-  const selectedChartData = useMemo(
-    () => chartData.slice(-windowDataPointLimit[selectedWindow]),
-    [selectedWindow]
-  );
+  const { prefs, update } = useChartPreferences();
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!isMenuOpen) {
-      return;
+  const baseTheme = useMemo(() => ({
+    background: resolvedTheme === "dark" ? "#081418" : "#ffffff",
+    text: resolvedTheme === "dark" ? "#ffffff" : "#0f1f2a",
+    muted: resolvedTheme === "dark" ? "#5e8c96" : "#4a7080",
+    grid: resolvedTheme === "dark" ? "rgba(94,140,150,0.07)" : "rgba(74,112,128,0.12)",
+    tooltipBg: resolvedTheme === "dark" ? "rgba(8,20,24,0.95)" : "rgba(255,255,255,0.98)",
+    tooltipBorder: resolvedTheme === "dark" ? "rgba(0,201,200,0.3)" : "rgba(8,145,178,0.18)",
+  }), [resolvedTheme]);
+
+  const palette = useMemo(() => colorSchemes[prefs.colorScheme][resolvedTheme], [prefs.colorScheme, resolvedTheme]);
+  const chartTheme = useMemo(() => ({ ...baseTheme, ...palette }), [baseTheme, palette]);
+
+  const chartData = useMemo(() => allChartData.slice(-windowLimits[prefs.timeRange]), [prefs.timeRange]);
+
+  const handleExportSvg = useCallback(() => {
+    const svg = containerRef.current?.querySelector("svg");
+    if (!svg) return;
+    const serialized = new XMLSerializer().serializeToString(svg);
+    downloadBlob(new Blob([serialized], { type: "image/svg+xml" }), "portfolio-chart.svg");
+  }, []);
+
+  const handleExportPng = useCallback(() => {
+    const svg = containerRef.current?.querySelector("svg");
+    if (!svg) return;
+    const svgData = new XMLSerializer().serializeToString(svg);
+    const canvas = document.createElement("canvas");
+    const rect = svg.getBoundingClientRect();
+    canvas.width = rect.width * 2;
+    canvas.height = rect.height * 2;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.scale(2, 2);
+    const img = new Image();
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob((blob) => { if (blob) downloadBlob(blob, "portfolio-chart.png"); });
+    };
+    img.src = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgData)))}`;
+  }, []);
+
+  const handleExportCsv = useCallback(() => {
+    const header = prefs.showComparison ? "date,value,prev" : "date,value";
+    const rows = chartData.map((d) =>
+      prefs.showComparison ? `${d.date},${d.value},${d.prev}` : `${d.date},${d.value}`
+    );
+    downloadBlob(new Blob([[header, ...rows].join("\n")], { type: "text/csv" }), "portfolio-chart.csv");
+  }, [chartData, prefs.showComparison]);
+
+  const commonProps = {
+    data: chartData,
+    margin: { top: 20, right: 24, bottom: 0, left: 24 },
+  };
+
+  const xAxis = <XAxis dataKey="date" axisLine={false} tickLine={false} tick={{ fill: chartTheme.muted, fontSize: 11 }} dy={10} interval={1} />;
+  const yAxis = <YAxis hide domain={["dataMin - 2000", "dataMax + 1000"]} />;
+  const grid = <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.grid} vertical={false} />;
+  const tooltip = <Tooltip content={<CustomTooltip theme={chartTheme} />} cursor={false} />;
+  const brush = prefs.showBrush ? (
+    <Brush
+      dataKey="date"
+      height={20}
+      stroke={chartTheme.grid}
+      fill={resolvedTheme === "dark" ? "rgba(8,20,24,0.6)" : "rgba(255,255,255,0.6)"}
+      travellerWidth={6}
+    />
+  ) : null;
+  const legend = prefs.showLegend ? <Legend wrapperStyle={{ color: chartTheme.muted, fontSize: 12 }} /> : null;
+
+  function renderChart(type: ChartType) {
+    if (type === "line") {
+      return (
+        <LineChart {...commonProps}>
+          {grid}{xAxis}{yAxis}{tooltip}{legend}{brush}
+          <Line type="monotone" dataKey="value" name="Portfolio" stroke={palette.accent} strokeWidth={2.5} dot={false} activeDot={{ r: 5, fill: palette.accent }} />
+          {prefs.showComparison && (
+            <Line type="monotone" dataKey="prev" name="Prev. period" stroke={palette.accentAlt} strokeWidth={2} dot={false} strokeDasharray="4 3" activeDot={{ r: 4, fill: palette.accentAlt }} />
+          )}
+        </LineChart>
+      );
     }
 
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) {
-        setIsMenuOpen(false);
-      }
-    };
+    if (type === "bar") {
+      return (
+        <BarChart {...commonProps}>
+          {grid}{xAxis}{yAxis}{tooltip}{legend}{brush}
+          <Bar dataKey="value" name="Portfolio" fill={palette.accent} radius={[4, 4, 0, 0]} maxBarSize={24} />
+          {prefs.showComparison && (
+            <Bar dataKey="prev" name="Prev. period" fill={palette.accentAlt} radius={[4, 4, 0, 0]} maxBarSize={24} />
+          )}
+        </BarChart>
+      );
+    }
 
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsMenuOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleEscape);
-
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [isMenuOpen]);
+    return (
+      <AreaChart {...commonProps}>
+        <defs>
+          <linearGradient id="portfolioAreaGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={palette.accent} stopOpacity={0.25} />
+            <stop offset="60%" stopColor={palette.accent} stopOpacity={0.06} />
+            <stop offset="100%" stopColor={palette.accent} stopOpacity={0} />
+          </linearGradient>
+          <linearGradient id="portfolioAreaGradPrev" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={palette.accentAlt} stopOpacity={0.18} />
+            <stop offset="100%" stopColor={palette.accentAlt} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        {grid}{xAxis}{yAxis}{tooltip}{legend}{brush}
+        {prefs.showComparison && (
+          <Area type="monotone" dataKey="prev" name="Prev. period" stroke={palette.accentAlt} strokeWidth={1.5} strokeDasharray="4 3" fill="url(#portfolioAreaGradPrev)" dot={false} />
+        )}
+        <Area type="monotone" dataKey="value" name="Portfolio" stroke={palette.accent} strokeWidth={2} fill="url(#portfolioAreaGrad)" activeDot={<ActiveDot theme={chartTheme} />} dot={false} />
+      </AreaChart>
+    );
+  }
 
   return (
     <div className="relative overflow-hidden rounded-2xl border border-[var(--color-border)] bg-linear-to-b from-[var(--color-card-start)] to-[var(--color-card-end)]">
-      <div className="flex items-start justify-between px-6 pt-6 pb-2">
+      <div className="flex flex-wrap items-start justify-between gap-4 px-6 pt-6 pb-2">
         <div>
           <p className="m-0 mb-1 text-[11px] uppercase tracking-[0.15em] text-[var(--color-text-muted)]">
             Total Portfolio Value
@@ -194,80 +237,33 @@ export default function PortfolioPerformanceChart() {
           </div>
         </div>
 
-        <div ref={menuRef} className="relative">
-          <button
-            type="button"
-            onClick={() => setIsMenuOpen((current) => !current)}
-            className="rounded-lg p-1.5 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
-            aria-label="Portfolio performance options"
-            aria-expanded={isMenuOpen}
-            aria-haspopup="menu"
-          >
-            <MoreHorizontal size={18} />
-          </button>
-
-          {isMenuOpen ? (
-            <div
-              role="menu"
-              aria-label="Portfolio time range"
-              className="absolute right-0 top-full z-20 mt-2 min-w-[150px] rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] p-1.5 shadow-xl"
-            >
-              {["7D", "30D", "90D"].map((windowLabel) => {
-                const selected = selectedWindow === windowLabel;
-                return (
-                  <button
-                    key={windowLabel}
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={selected}
-                    onClick={() => {
-                      setSelectedWindow(windowLabel);
-                      setIsMenuOpen(false);
-                    }}
-                    className={`flex w-full items-center rounded-xl px-3 py-2 text-sm ${
-                      selected
-                        ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
-                        : "text-[var(--color-text)] hover:bg-[var(--color-surface-subtle)]"
-                    }`}
-                  >
-                    {windowLabel}
-                  </button>
-                );
-              })}
-            </div>
-          ) : null}
-        </div>
+        <ChartControls
+          chartType={prefs.chartType}
+          timeRange={prefs.timeRange}
+          colorScheme={prefs.colorScheme}
+          showLegend={prefs.showLegend}
+          showComparison={prefs.showComparison}
+          showBrush={prefs.showBrush}
+          onChartType={(v) => update("chartType", v)}
+          onTimeRange={(v) => update("timeRange", v)}
+          onColorScheme={(v) => update("colorScheme", v)}
+          onLegendToggle={() => update("showLegend", !prefs.showLegend)}
+          onComparisonToggle={() => update("showComparison", !prefs.showComparison)}
+          onBrushToggle={() => update("showBrush", !prefs.showBrush)}
+          onExportPng={handleExportPng}
+          onExportSvg={handleExportSvg}
+          onExportCsv={handleExportCsv}
+        />
       </div>
 
       <div className="px-6 pb-1 text-sm text-[var(--color-text-soft)]">
-        Viewing the last {selectedWindow.toLowerCase()} of portfolio movement.
+        Viewing the last {prefs.timeRange.toLowerCase()} of portfolio movement.
+        {prefs.showComparison && <span className="ml-1 text-[var(--color-text-muted)]">· Comparing previous period.</span>}
       </div>
 
-      <div className="w-full" style={{ height: 260 }}>
+      <div ref={containerRef} className="w-full" style={{ height: prefs.showBrush ? 300 : 260 }}>
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={selectedChartData} margin={{ top: 20, right: 24, bottom: 0, left: 24 }}>
-            <defs>
-              <linearGradient id="portfolioAreaGrad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={chartTheme.accent} stopOpacity={0.25} />
-                <stop offset="60%" stopColor={chartTheme.accent} stopOpacity={0.06} />
-                <stop offset="100%" stopColor={chartTheme.accent} stopOpacity={0} />
-              </linearGradient>
-            </defs>
-
-            <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.grid} vertical={false} />
-            <XAxis dataKey="date" axisLine={false} tickLine={false} tick={{ fill: chartTheme.muted, fontSize: 11 }} dy={10} interval={1} />
-            <YAxis hide domain={["dataMin - 2000", "dataMax + 1000"]} />
-            <Tooltip content={<CustomTooltip theme={chartTheme} />} cursor={false} />
-            <Area
-              type="monotone"
-              dataKey="value"
-              stroke={chartTheme.accent}
-              strokeWidth={2}
-              fill="url(#portfolioAreaGrad)"
-              activeDot={<ActiveDot theme={chartTheme} />}
-              dot={false}
-            />
-          </AreaChart>
+          {renderChart(prefs.chartType)}
         </ResponsiveContainer>
       </div>
     </div>

--- a/frontend/app/dashboard/analytics/useChartPreferences.ts
+++ b/frontend/app/dashboard/analytics/useChartPreferences.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type ChartType = "area" | "line" | "bar";
+export type TimeRange = "7D" | "30D" | "90D" | "1Y";
+export type ColorScheme = "default" | "ocean" | "sunset" | "forest";
+
+export type ChartPreferences = {
+  chartType: ChartType;
+  timeRange: TimeRange;
+  colorScheme: ColorScheme;
+  showLegend: boolean;
+  showComparison: boolean;
+  showBrush: boolean;
+};
+
+const STORAGE_KEY = "nestera-chart-prefs";
+
+const defaults: ChartPreferences = {
+  chartType: "area",
+  timeRange: "30D",
+  colorScheme: "default",
+  showLegend: false,
+  showComparison: false,
+  showBrush: false,
+};
+
+function readStorage(): Partial<ChartPreferences> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Partial<ChartPreferences>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function useChartPreferences() {
+  const [prefs, setPrefs] = useState<ChartPreferences>(defaults);
+
+  useEffect(() => {
+    setPrefs({ ...defaults, ...readStorage() });
+  }, []);
+
+  const update = useCallback(<K extends keyof ChartPreferences>(key: K, value: ChartPreferences[K]) => {
+    setPrefs((prev) => {
+      const next = { ...prev, [key]: value };
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  return { prefs, update };
+}
+
+export type ColorSchemePalette = {
+  accent: string;
+  accentAlt: string;
+  accentSoft: string;
+  success: string;
+  violet: string;
+};
+
+export const colorSchemes: Record<ColorScheme, Record<"light" | "dark", ColorSchemePalette>> = {
+  default: {
+    light: { accent: "#0891b2", accentAlt: "#2563eb", accentSoft: "rgba(8,145,178,0.18)", success: "#059669", violet: "#7c3aed" },
+    dark:  { accent: "#00c9c8", accentAlt: "#60a5fa", accentSoft: "rgba(0,201,200,0.18)", success: "#34d399", violet: "#a78bfa" },
+  },
+  ocean: {
+    light: { accent: "#1d4ed8", accentAlt: "#7c3aed", accentSoft: "rgba(29,78,216,0.15)", success: "#0891b2", violet: "#4f46e5" },
+    dark:  { accent: "#60a5fa", accentAlt: "#a78bfa", accentSoft: "rgba(96,165,250,0.18)", success: "#38bdf8", violet: "#818cf8" },
+  },
+  sunset: {
+    light: { accent: "#ea580c", accentAlt: "#d97706", accentSoft: "rgba(234,88,12,0.15)", success: "#16a34a", violet: "#db2777" },
+    dark:  { accent: "#fb923c", accentAlt: "#fbbf24", accentSoft: "rgba(251,146,60,0.18)", success: "#4ade80", violet: "#f472b6" },
+  },
+  forest: {
+    light: { accent: "#16a34a", accentAlt: "#0891b2", accentSoft: "rgba(22,163,74,0.15)", success: "#15803d", violet: "#7c3aed" },
+    dark:  { accent: "#4ade80", accentAlt: "#34d399", accentSoft: "rgba(74,222,128,0.18)", success: "#86efac", violet: "#a78bfa" },
+  },
+};


### PR DESCRIPTION
Closes #861

## Summary

- Added chart type switching (Area / Line / Bar) to the Portfolio Performance chart and all four Comparison Grid cards
- Added time range selector (7D / 30D / 90D / 1Y) as inline pills, replacing the hidden dropdown
- Added zoom & pan via a Recharts `Brush` scrubber on all charts
- Added four color scheme presets (Teal, Ocean, Sunset, Forest) per chart, independent across cards
- Added legend toggle on all charts
- Added comparison mode to Portfolio Performance (overlays a dashed previous-period series)
- Added export to PNG, SVG, and CSV on all charts
- Persists Portfolio Performance preferences (chart type, time range, color scheme, etc.) to `localStorage`

## Files changed

- `useChartPreferences.ts` — new hook for reading/writing chart prefs to localStorage; exports `colorSchemes` palette map used by all charts
- `ChartControls.tsx` — new reusable toolbar component used by `PortfolioPerformanceChart`
- `PortfolioPerformanceChart.tsx` — wired up all controls; dynamically renders `AreaChart`, `LineChart`, or `BarChart`
- `AnalyticsComparisonGrid.tsx` — each card now owns independent state for chart type, color scheme, brush, and legend; render prop updated to pass `palette` and `showBrush` down to chart children