### PR TITLE
Add backend currency abstraction layer

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,6 +21,12 @@ RPC_TIMEOUT=10000
 # Contract
 CONTRACT_ID=YOUR_DEPLOYED_CONTRACT_ID
 
+# Currency support
+BASE_CURRENCY=USDC
+# Optional JSON override keyed by USDC, USDT, XLM, or EURC.
+# Example: {"XLM":{"conversion":{"rateToBase":"0.11"}}}
+CURRENCY_CONFIG_JSON=
+
 # ── Database ──────────────────────────────────────────────────────────────────
 # Option A – URL-based (takes precedence; typical for cloud/container deployments)
 DATABASE_URL=postgresql://user:password@localhost:5432/nestera

--- a/backend/scripts/generate-openapi-spec.ts
+++ b/backend/scripts/generate-openapi-spec.ts
@@ -32,10 +32,14 @@ async function generate() {
     .setTitle('Nestera API')
     .setDescription(
       'Nestera is a decentralized savings & investment platform on Stellar. ' +
-      'All amounts are in USDC (7 decimal places).',
+        'Amounts include currency metadata and use currency-specific precision.',
     )
     .setVersion('2')
-    .setContact('Nestera Team', 'https://github.com/Devsol-01/Nestera', 'support@nestera.io')
+    .setContact(
+      'Nestera Team',
+      'https://github.com/Devsol-01/Nestera',
+      'support@nestera.io',
+    )
     .setLicense('MIT', 'https://opensource.org/licenses/MIT')
     .addServer('http://localhost:3001', 'Local development')
     .addServer('https://api.nestera.io', 'Production')

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -37,6 +37,7 @@ import { NotificationsModule } from './modules/notifications/notifications.modul
 import { TransactionsModule } from './modules/transactions/transactions.module';
 import { ReportsModule } from './modules/reports/reports.module';
 import { ReferralsModule } from './modules/referrals/referrals.module';
+import { CurrencyModule } from './modules/currency/currency.module';
 import { TestRbacModule } from './test-rbac/test-rbac.module';
 import { TestThrottlingModule } from './test-throttling/test-throttling.module';
 import { ApiVersioningModule } from './common/versioning/api-versioning.module';
@@ -94,6 +95,10 @@ const envValidationSchema = Joi.object({
   BACKUP_ENCRYPTION_KEY: Joi.string().length(64).optional(), // 32-byte key as hex
   BACKUP_RETENTION_DAYS: Joi.number().integer().min(1).default(30).optional(),
   BACKUP_TMP_DIR: Joi.string().optional(),
+  BASE_CURRENCY: Joi.string()
+    .valid('USDC', 'USDT', 'XLM', 'EURC')
+    .default('USDC'),
+  CURRENCY_CONFIG_JSON: Joi.string().optional(),
 });
 
 @Module({
@@ -200,6 +205,7 @@ const envValidationSchema = Joi.object({
     TransactionsModule,
     ReportsModule,
     ReferralsModule,
+    CurrencyModule,
     TestRbacModule,
     TestThrottlingModule,
     ApiVersioningModule,

--- a/backend/src/common/interceptors/transaction-formatting.interceptor.ts
+++ b/backend/src/common/interceptors/transaction-formatting.interceptor.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { CurrencyService } from '../../modules/currency/currency.service';
 
 /**
  * Asset configuration for formatting precision and symbols
@@ -48,6 +49,8 @@ const ASSET_CONFIGS: Record<string, AssetConfig> = {
  */
 @Injectable()
 export class TransactionFormattingInterceptor implements NestInterceptor {
+  constructor(private readonly currencyService: CurrencyService) {}
+
   /**
    * Intercept and enrich transaction responses
    */
@@ -105,7 +108,7 @@ export class TransactionFormattingInterceptor implements NestInterceptor {
     if (formatted.amount !== undefined) {
       formatted.amountFormatted = this.formatAmount(
         formatted.amount,
-        formatted.assetId || formatted.contractId,
+        formatted.currencyCode,
       );
     }
 
@@ -142,6 +145,10 @@ export class TransactionFormattingInterceptor implements NestInterceptor {
    * @returns Formatted amount object with multiple representations
    */
   private formatAmount(amount: string | number, assetId?: string): any {
+    if (assetId && ['USDC', 'USDT', 'XLM', 'EURC'].includes(assetId)) {
+      return this.currencyService.formatAmount(amount, assetId);
+    }
+
     const assetConfig = this.getAssetConfig(assetId);
     const rawAmount = typeof amount === 'string' ? amount : amount.toString();
 

--- a/backend/src/common/validators/is-positive-amount.validator.ts
+++ b/backend/src/common/validators/is-positive-amount.validator.ts
@@ -3,6 +3,10 @@ import {
   ValidationOptions,
   ValidationArguments,
 } from 'class-validator';
+import {
+  DEFAULT_CURRENCY_CONFIGS,
+  normalizeCurrencyCode,
+} from '../../modules/currency/currency.config';
 
 export function IsPositiveAmount(validationOptions?: ValidationOptions) {
   return function (object: object, propertyName: string) {
@@ -13,7 +17,8 @@ export function IsPositiveAmount(validationOptions?: ValidationOptions) {
       options: validationOptions,
       validator: {
         validate(value: unknown): boolean {
-          const num = typeof value === 'string' ? parseFloat(value) : Number(value);
+          const num =
+            typeof value === 'string' ? parseFloat(value) : Number(value);
           return isFinite(num) && num > 0;
         },
         defaultMessage(args: ValidationArguments): string {
@@ -25,23 +30,52 @@ export function IsPositiveAmount(validationOptions?: ValidationOptions) {
 }
 
 export function IsUSDCAmount(validationOptions?: ValidationOptions) {
+  return IsCurrencyAmount(undefined, validationOptions);
+}
+
+export function IsCurrencyAmount(
+  currencyProperty = 'currencyCode',
+  validationOptions?: ValidationOptions,
+) {
   return function (object: object, propertyName: string) {
     registerDecorator({
-      name: 'isUSDCAmount',
+      name: 'isCurrencyAmount',
       target: object.constructor,
       propertyName,
       options: validationOptions,
       validator: {
-        validate(value: unknown): boolean {
-          const num = typeof value === 'string' ? parseFloat(value) : Number(value);
+        validate(value: unknown, args: ValidationArguments): boolean {
+          const objectWithCurrency = args.object as Record<string, unknown>;
+          let currencyCode: keyof typeof DEFAULT_CURRENCY_CONFIGS;
+          try {
+            currencyCode = normalizeCurrencyCode(
+              String(objectWithCurrency[currencyProperty] || 'USDC'),
+            );
+          } catch {
+            return false;
+          }
+
+          const config = DEFAULT_CURRENCY_CONFIGS[currencyCode];
+          const num =
+            typeof value === 'string' ? parseFloat(value) : Number(value);
           if (!isFinite(num) || num <= 0) return false;
-          // USDC uses 7 decimal places on Stellar
           const strVal = String(value);
           const decimalPart = strVal.split('.')[1] || '';
-          return decimalPart.length <= 7;
+          return decimalPart.length <= config.validation.maxDecimalPlaces;
         },
         defaultMessage(args: ValidationArguments): string {
-          return `${args.property} must be a positive USDC amount with at most 7 decimal places`;
+          const objectWithCurrency = args.object as Record<string, unknown>;
+          let currencyCode: keyof typeof DEFAULT_CURRENCY_CONFIGS;
+          try {
+            currencyCode = normalizeCurrencyCode(
+              String(objectWithCurrency[currencyProperty] || 'USDC'),
+            );
+          } catch {
+            return `${args.property} must use a supported currency code`;
+          }
+
+          const config = DEFAULT_CURRENCY_CONFIGS[currencyCode];
+          return `${args.property} must be a positive ${currencyCode} amount with at most ${config.validation.maxDecimalPlaces} decimal places`;
         },
       },
     });
@@ -57,7 +91,8 @@ export function IsNonNegativeAmount(validationOptions?: ValidationOptions) {
       options: validationOptions,
       validator: {
         validate(value: unknown): boolean {
-          const num = typeof value === 'string' ? parseFloat(value) : Number(value);
+          const num =
+            typeof value === 'string' ? parseFloat(value) : Number(value);
           return isFinite(num) && num >= 0;
         },
         defaultMessage(args: ValidationArguments): string {

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -114,4 +114,8 @@ export default () => ({
       10,
     ),
   },
+  currency: {
+    baseCurrency: process.env.BASE_CURRENCY || 'USDC',
+    configJson: process.env.CURRENCY_CONFIG_JSON,
+  },
 });

--- a/backend/src/migrations/1801000000000-AddMultiCurrencyColumns.ts
+++ b/backend/src/migrations/1801000000000-AddMultiCurrencyColumns.ts
@@ -1,0 +1,71 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMultiCurrencyColumns1801000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "transactions"
+      ADD COLUMN IF NOT EXISTS "currencyCode" varchar(12) NOT NULL DEFAULT 'USDC',
+      ADD COLUMN IF NOT EXISTS "assetCode" varchar(12),
+      ADD COLUMN IF NOT EXISTS "assetIssuer" varchar(128),
+      ADD COLUMN IF NOT EXISTS "assetContractId" varchar(128),
+      ADD COLUMN IF NOT EXISTS "amountBaseCurrency" decimal(18,7),
+      ADD COLUMN IF NOT EXISTS "conversionRateToBase" decimal(18,7);
+    `);
+
+    await queryRunner.query(`
+      UPDATE "transactions"
+      SET
+        "currencyCode" = COALESCE("currencyCode", 'USDC'),
+        "assetCode" = COALESCE("assetCode", 'USDC'),
+        "assetContractId" = COALESCE(
+          "assetContractId",
+          NULLIF(("metadata"->>'assetId'), ''),
+          NULLIF(("metadata"->>'contractId'), '')
+        ),
+        "conversionRateToBase" = COALESCE("conversionRateToBase", 1),
+        "amountBaseCurrency" = COALESCE("amountBaseCurrency", "amount")
+      WHERE "currencyCode" IS NULL OR "amountBaseCurrency" IS NULL;
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_transactions_currency_code"
+      ON "transactions" ("currencyCode");
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "savings_products"
+      ADD COLUMN IF NOT EXISTS "currencyCode" varchar(12) NOT NULL DEFAULT 'USDC';
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "user_subscriptions"
+      ADD COLUMN IF NOT EXISTS "currencyCode" varchar(12) NOT NULL DEFAULT 'USDC';
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user_subscriptions"
+      DROP COLUMN IF EXISTS "currencyCode";
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "savings_products"
+      DROP COLUMN IF EXISTS "currencyCode";
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "idx_transactions_currency_code";
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "transactions"
+      DROP COLUMN IF EXISTS "conversionRateToBase",
+      DROP COLUMN IF EXISTS "amountBaseCurrency",
+      DROP COLUMN IF EXISTS "assetContractId",
+      DROP COLUMN IF EXISTS "assetIssuer",
+      DROP COLUMN IF EXISTS "assetCode",
+      DROP COLUMN IF EXISTS "currencyCode";
+    `);
+  }
+}

--- a/backend/src/modules/blockchain/blockchain.module.ts
+++ b/backend/src/modules/blockchain/blockchain.module.ts
@@ -22,6 +22,7 @@ import { YieldHandler } from './event-handlers/yield.handler';
 import { IndexerService } from './indexer.service';
 import { BalanceSyncService } from './balance-sync.service';
 import { ProtocolMetrics } from '../admin-analytics/entities/protocol-metrics.entity';
+import { CurrencyModule } from '../currency/currency.module';
 
 @Global()
 @Module({
@@ -42,6 +43,7 @@ import { ProtocolMetrics } from '../admin-analytics/entities/protocol-metrics.en
       SavingsProduct,
       ProtocolMetrics,
     ]),
+    CurrencyModule,
   ],
   controllers: [BlockchainController, StellarEventListenerController],
   providers: [

--- a/backend/src/modules/blockchain/event-handlers/deposit.handler.ts
+++ b/backend/src/modules/blockchain/event-handlers/deposit.handler.ts
@@ -13,6 +13,7 @@ import {
 } from '../../savings/entities/user-subscription.entity';
 import { User } from '../../user/entities/user.entity';
 import { SavingsProduct } from '../../savings/entities/savings-product.entity';
+import { CurrencyService } from '../../currency/currency.service';
 
 interface IndexerEvent {
   id?: string;
@@ -26,6 +27,10 @@ interface IndexerEvent {
 interface DepositPayload {
   publicKey: string;
   amount: string;
+  currencyCode: string;
+  assetCode: string | null;
+  assetIssuer: string | null;
+  assetContractId: string | null;
 }
 
 @Injectable()
@@ -35,7 +40,10 @@ export class DepositHandler {
     .update('Deposit')
     .digest('hex');
 
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly currencyService: CurrencyService,
+  ) {}
 
   async handle(event: IndexerEvent): Promise<boolean> {
     if (!this.isDepositTopic(event.topic)) {
@@ -43,6 +51,11 @@ export class DepositHandler {
     }
 
     const payload = this.extractPayload(event.value);
+    const currency = this.currencyService.resolveCurrencyFromAsset(payload);
+    const normalizedAmount = this.currencyService.normalizeAmount(
+      payload.amount,
+      currency.code,
+    );
     const eventId = this.resolveEventId(event);
 
     await this.dataSource.transaction(async (manager) => {
@@ -77,6 +90,13 @@ export class DepositHandler {
           userId: user.id,
           type: LedgerTransactionType.DEPOSIT,
           amount: payload.amount,
+          currencyCode: currency.code,
+          assetCode: payload.assetCode ?? currency.stellarAssetCode,
+          assetIssuer: payload.assetIssuer ?? currency.issuer ?? null,
+          assetContractId:
+            payload.assetContractId ?? currency.contractId ?? null,
+          amountBaseCurrency: normalizedAmount.amountBaseCurrency,
+          conversionRateToBase: normalizedAmount.conversionRateToBase,
           publicKey: payload.publicKey,
           eventId,
           transactionHash:
@@ -86,6 +106,7 @@ export class DepositHandler {
           metadata: {
             topic: event.topic,
             rawValueType: typeof event.value,
+            currencyCode: currency.code,
           },
         }),
       );
@@ -120,6 +141,7 @@ export class DepositHandler {
           userId: user.id,
           productId: defaultProduct.id,
           amount: amountAsNumber,
+          currencyCode: currency.code,
           status: SubscriptionStatus.ACTIVE,
           startDate: new Date(),
           endDate: null,
@@ -194,7 +216,22 @@ export class DepositHandler {
       );
     }
 
-    return { publicKey, amount };
+    return { publicKey, amount, ...this.extractCurrencyFields(asRecord) };
+  }
+
+  private extractCurrencyFields(record: Record<string, unknown>) {
+    return {
+      currencyCode:
+        this.pickString(record, ['currencyCode', 'currency', 'asset']) ??
+        'USDC',
+      assetCode: this.pickString(record, ['assetCode', 'code']),
+      assetIssuer: this.pickString(record, ['assetIssuer', 'issuer']),
+      assetContractId: this.pickString(record, [
+        'assetContractId',
+        'contractId',
+        'assetId',
+      ]),
+    };
   }
 
   private resolveEventId(event: IndexerEvent): string {

--- a/backend/src/modules/blockchain/event-handlers/withdraw.handler.ts
+++ b/backend/src/modules/blockchain/event-handlers/withdraw.handler.ts
@@ -13,6 +13,7 @@ import {
   UserSubscription,
 } from '../../savings/entities/user-subscription.entity';
 import { User } from '../../user/entities/user.entity';
+import { CurrencyService } from '../../currency/currency.service';
 
 interface IndexerEvent {
   id?: string;
@@ -26,6 +27,10 @@ interface IndexerEvent {
 interface WithdrawPayload {
   publicKey: string;
   amount: string;
+  currencyCode: string;
+  assetCode: string | null;
+  assetIssuer: string | null;
+  assetContractId: string | null;
 }
 
 @Injectable()
@@ -35,7 +40,10 @@ export class WithdrawHandler {
     .update('Withdraw')
     .digest('hex');
 
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly currencyService: CurrencyService,
+  ) {}
 
   async handle(event: IndexerEvent): Promise<boolean> {
     if (!this.isWithdrawTopic(event.topic)) {
@@ -43,6 +51,11 @@ export class WithdrawHandler {
     }
 
     const payload = this.extractPayload(event.value);
+    const currency = this.currencyService.resolveCurrencyFromAsset(payload);
+    const normalizedAmount = this.currencyService.normalizeAmount(
+      payload.amount,
+      currency.code,
+    );
     const eventId = this.resolveEventId(event);
 
     await this.dataSource.transaction(async (manager) => {
@@ -76,6 +89,13 @@ export class WithdrawHandler {
           userId: user.id,
           type: LedgerTransactionType.WITHDRAW,
           amount: payload.amount,
+          currencyCode: currency.code,
+          assetCode: payload.assetCode ?? currency.stellarAssetCode,
+          assetIssuer: payload.assetIssuer ?? currency.issuer ?? null,
+          assetContractId:
+            payload.assetContractId ?? currency.contractId ?? null,
+          amountBaseCurrency: normalizedAmount.amountBaseCurrency,
+          conversionRateToBase: normalizedAmount.conversionRateToBase,
           publicKey: payload.publicKey,
           eventId,
           status: LedgerTransactionStatus.COMPLETED,
@@ -86,6 +106,7 @@ export class WithdrawHandler {
           metadata: {
             topic: event.topic,
             rawValueType: typeof event.value,
+            currencyCode: currency.code,
           },
         }),
       );
@@ -177,7 +198,22 @@ export class WithdrawHandler {
       );
     }
 
-    return { publicKey, amount };
+    return { publicKey, amount, ...this.extractCurrencyFields(asRecord) };
+  }
+
+  private extractCurrencyFields(record: Record<string, unknown>) {
+    return {
+      currencyCode:
+        this.pickString(record, ['currencyCode', 'currency', 'asset']) ??
+        'USDC',
+      assetCode: this.pickString(record, ['assetCode', 'code']),
+      assetIssuer: this.pickString(record, ['assetIssuer', 'issuer']),
+      assetContractId: this.pickString(record, [
+        'assetContractId',
+        'contractId',
+        'assetId',
+      ]),
+    };
   }
 
   private resolveEventId(event: IndexerEvent): string {

--- a/backend/src/modules/blockchain/event-handlers/yield.handler.ts
+++ b/backend/src/modules/blockchain/event-handlers/yield.handler.ts
@@ -14,6 +14,7 @@ import {
 } from '../../savings/entities/user-subscription.entity';
 import { User } from '../../user/entities/user.entity';
 import { SavingsProduct } from '../../savings/entities/savings-product.entity';
+import { CurrencyService } from '../../currency/currency.service';
 
 interface IndexerEvent {
   id?: string;
@@ -27,6 +28,10 @@ interface IndexerEvent {
 interface YieldPayload {
   publicKey: string;
   amount: string; // This represents the interest earned
+  currencyCode: string;
+  assetCode: string | null;
+  assetIssuer: string | null;
+  assetContractId: string | null;
 }
 
 @Injectable()
@@ -36,7 +41,10 @@ export class YieldHandler {
     .update('Yield')
     .digest('hex');
 
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly currencyService: CurrencyService,
+  ) {}
 
   async handle(event: IndexerEvent): Promise<boolean> {
     if (!this.isYieldTopic(event.topic)) {
@@ -44,6 +52,11 @@ export class YieldHandler {
     }
 
     const payload = this.extractPayload(event.value);
+    const currency = this.currencyService.resolveCurrencyFromAsset(payload);
+    const normalizedAmount = this.currencyService.normalizeAmount(
+      payload.amount,
+      currency.code,
+    );
     const eventId = this.resolveEventId(event);
 
     await this.dataSource.transaction(async (manager) => {
@@ -77,6 +90,13 @@ export class YieldHandler {
           userId: user.id,
           type: LedgerTransactionType.YIELD,
           amount: payload.amount,
+          currencyCode: currency.code,
+          assetCode: payload.assetCode ?? currency.stellarAssetCode,
+          assetIssuer: payload.assetIssuer ?? currency.issuer ?? null,
+          assetContractId:
+            payload.assetContractId ?? currency.contractId ?? null,
+          amountBaseCurrency: normalizedAmount.amountBaseCurrency,
+          conversionRateToBase: normalizedAmount.conversionRateToBase,
           publicKey: payload.publicKey,
           eventId,
           status: LedgerTransactionStatus.COMPLETED,
@@ -87,6 +107,7 @@ export class YieldHandler {
           metadata: {
             topic: event.topic,
             rawValueType: typeof event.value,
+            currencyCode: currency.code,
           },
         }),
       );
@@ -196,7 +217,22 @@ export class YieldHandler {
       );
     }
 
-    return { publicKey, amount };
+    return { publicKey, amount, ...this.extractCurrencyFields(asRecord) };
+  }
+
+  private extractCurrencyFields(record: Record<string, unknown>) {
+    return {
+      currencyCode:
+        this.pickString(record, ['currencyCode', 'currency', 'asset']) ??
+        'USDC',
+      assetCode: this.pickString(record, ['assetCode', 'code']),
+      assetIssuer: this.pickString(record, ['assetIssuer', 'issuer']),
+      assetContractId: this.pickString(record, [
+        'assetContractId',
+        'contractId',
+        'assetId',
+      ]),
+    };
   }
 
   private resolveEventId(event: IndexerEvent): string {

--- a/backend/src/modules/currency/currency.config.ts
+++ b/backend/src/modules/currency/currency.config.ts
@@ -1,0 +1,92 @@
+import { CurrencyCode, CurrencyConfig } from './currency.types';
+
+export const DEFAULT_BASE_CURRENCY = CurrencyCode.USDC;
+
+export const DEFAULT_CURRENCY_CONFIGS: Record<CurrencyCode, CurrencyConfig> = {
+  [CurrencyCode.USDC]: {
+    code: CurrencyCode.USDC,
+    displayName: 'USD Coin',
+    symbol: '$',
+    decimals: 7,
+    type: 'stablecoin',
+    stellarAssetCode: 'USDC',
+    issuer: null,
+    contractId: 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA',
+    enabled: true,
+    validation: {
+      minAmount: '0.0000001',
+      maxDecimalPlaces: 7,
+    },
+    conversion: {
+      baseCurrency: CurrencyCode.USDC,
+      rateToBase: '1',
+    },
+  },
+  [CurrencyCode.USDT]: {
+    code: CurrencyCode.USDT,
+    displayName: 'Tether USD',
+    symbol: 'USDT',
+    decimals: 7,
+    type: 'stablecoin',
+    stellarAssetCode: 'USDT',
+    issuer: null,
+    contractId: null,
+    enabled: true,
+    validation: {
+      minAmount: '0.0000001',
+      maxDecimalPlaces: 7,
+    },
+    conversion: {
+      baseCurrency: CurrencyCode.USDC,
+      rateToBase: '1',
+    },
+  },
+  [CurrencyCode.XLM]: {
+    code: CurrencyCode.XLM,
+    displayName: 'Stellar Lumens',
+    symbol: 'XLM',
+    decimals: 7,
+    type: 'native',
+    stellarAssetCode: 'XLM',
+    issuer: null,
+    contractId: null,
+    enabled: true,
+    validation: {
+      minAmount: '0.0000001',
+      maxDecimalPlaces: 7,
+    },
+    conversion: {
+      baseCurrency: CurrencyCode.USDC,
+      rateToBase: '0.10',
+    },
+  },
+  [CurrencyCode.EURC]: {
+    code: CurrencyCode.EURC,
+    displayName: 'EUR Stablecoin',
+    symbol: 'EUR',
+    decimals: 7,
+    type: 'stablecoin',
+    stellarAssetCode: 'EURC',
+    issuer: null,
+    contractId: null,
+    enabled: true,
+    validation: {
+      minAmount: '0.0000001',
+      maxDecimalPlaces: 7,
+    },
+    conversion: {
+      baseCurrency: CurrencyCode.USDC,
+      rateToBase: '1.08',
+    },
+  },
+};
+
+export function normalizeCurrencyCode(value?: string | null): CurrencyCode {
+  const normalized = (value || DEFAULT_BASE_CURRENCY).trim().toUpperCase();
+
+  if (Object.values(CurrencyCode).includes(normalized as CurrencyCode)) {
+    return normalized as CurrencyCode;
+  }
+
+  throw new Error(`Unsupported currency code: ${normalized}`);
+}

--- a/backend/src/modules/currency/currency.controller.ts
+++ b/backend/src/modules/currency/currency.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CurrencyService } from './currency.service';
+
+@ApiTags('Currencies')
+@Controller('currencies')
+export class CurrencyController {
+  constructor(private readonly currencyService: CurrencyService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List supported currencies and validation/conversion metadata',
+  })
+  listSupportedCurrencies() {
+    return this.currencyService.listSupportedCurrencies();
+  }
+}

--- a/backend/src/modules/currency/currency.module.ts
+++ b/backend/src/modules/currency/currency.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { CurrencyController } from './currency.controller';
+import { CurrencyService } from './currency.service';
+
+@Global()
+@Module({
+  controllers: [CurrencyController],
+  providers: [CurrencyService],
+  exports: [CurrencyService],
+})
+export class CurrencyModule {}

--- a/backend/src/modules/currency/currency.service.spec.ts
+++ b/backend/src/modules/currency/currency.service.spec.ts
@@ -1,0 +1,44 @@
+import { ConfigService } from '@nestjs/config';
+import { CurrencyService } from './currency.service';
+import { CurrencyCode } from './currency.types';
+
+describe('CurrencyService', () => {
+  let service: CurrencyService;
+
+  beforeEach(() => {
+    service = new CurrencyService({
+      get: jest.fn().mockReturnValue(undefined),
+    } as unknown as ConfigService);
+  });
+
+  it('lists configured multi-currency support', () => {
+    const codes = service.listSupportedCurrencies().map((item) => item.code);
+
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        CurrencyCode.USDC,
+        CurrencyCode.USDT,
+        CurrencyCode.XLM,
+        CurrencyCode.EURC,
+      ]),
+    );
+  });
+
+  it('validates currency-specific decimal precision', () => {
+    expect(() =>
+      service.validateAmount('1.12345678', CurrencyCode.USDC),
+    ).toThrow('USDC amount must have at most 7 decimal places');
+  });
+
+  it('rejects unsupported currencies', () => {
+    expect(() => service.getConfig('BTC')).toThrow(
+      'Currency BTC is not supported',
+    );
+  });
+
+  it('converts configured currencies to the base currency', () => {
+    expect(service.convert('10', CurrencyCode.XLM, CurrencyCode.USDC)).toBe(
+      '1.0000000',
+    );
+  });
+});

--- a/backend/src/modules/currency/currency.service.ts
+++ b/backend/src/modules/currency/currency.service.ts
@@ -1,0 +1,193 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  DEFAULT_BASE_CURRENCY,
+  DEFAULT_CURRENCY_CONFIGS,
+  normalizeCurrencyCode,
+} from './currency.config';
+import {
+  CurrencyCode,
+  CurrencyConfig,
+  NormalizedCurrencyAmount,
+} from './currency.types';
+
+@Injectable()
+export class CurrencyService {
+  private readonly currencies: Record<CurrencyCode, CurrencyConfig>;
+
+  constructor(private readonly configService: ConfigService) {
+    this.currencies = this.loadCurrencyConfigs();
+  }
+
+  listSupportedCurrencies(): CurrencyConfig[] {
+    return Object.values(this.currencies).filter(
+      (currency) => currency.enabled,
+    );
+  }
+
+  getConfig(code?: string | null): CurrencyConfig {
+    let currencyCode: CurrencyCode;
+    try {
+      currencyCode = normalizeCurrencyCode(code);
+    } catch {
+      throw new BadRequestException(`Currency ${code} is not supported`);
+    }
+
+    const config = this.currencies[currencyCode];
+
+    if (!config || !config.enabled) {
+      throw new BadRequestException(
+        `Currency ${currencyCode} is not supported`,
+      );
+    }
+
+    return config;
+  }
+
+  resolveCurrencyFromAsset(input: {
+    currencyCode?: string | null;
+    assetCode?: string | null;
+    assetContractId?: string | null;
+  }): CurrencyConfig {
+    if (input.currencyCode) {
+      return this.getConfig(input.currencyCode);
+    }
+
+    const assetCode = input.assetCode?.toUpperCase();
+    const assetContractId = input.assetContractId;
+    const match = this.listSupportedCurrencies().find(
+      (currency) =>
+        currency.stellarAssetCode.toUpperCase() === assetCode ||
+        (assetContractId && currency.contractId === assetContractId),
+    );
+
+    return match || this.getConfig(DEFAULT_BASE_CURRENCY);
+  }
+
+  validateAmount(amount: string | number, code?: string | null): void {
+    const config = this.getConfig(code);
+    const raw = String(amount);
+    const numeric = Number(raw);
+
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      throw new BadRequestException(
+        `${config.code} amount must be a positive number`,
+      );
+    }
+
+    const decimalPart = raw.split('.')[1] || '';
+    if (decimalPart.length > config.validation.maxDecimalPlaces) {
+      throw new BadRequestException(
+        `${config.code} amount must have at most ${config.validation.maxDecimalPlaces} decimal places`,
+      );
+    }
+
+    if (numeric < Number(config.validation.minAmount)) {
+      throw new BadRequestException(
+        `${config.code} amount must be at least ${config.validation.minAmount}`,
+      );
+    }
+  }
+
+  normalizeAmount(
+    amount: string | number,
+    code?: string | null,
+  ): NormalizedCurrencyAmount {
+    const config = this.getConfig(code);
+    this.validateAmount(amount, config.code);
+
+    const amountString = String(amount);
+    const conversionRate = Number(config.conversion.rateToBase);
+    const amountBaseCurrency = Number(amountString) * conversionRate;
+
+    return {
+      amount: amountString,
+      currencyCode: config.code,
+      amountBaseCurrency: amountBaseCurrency.toFixed(config.decimals),
+      conversionRateToBase: config.conversion.rateToBase,
+    };
+  }
+
+  convert(
+    amount: string | number,
+    fromCurrency: string,
+    toCurrency = DEFAULT_BASE_CURRENCY,
+  ): string {
+    const from = this.getConfig(fromCurrency);
+    const to = this.getConfig(toCurrency);
+    this.validateAmount(amount, from.code);
+
+    const amountInBase = Number(amount) * Number(from.conversion.rateToBase);
+    const converted = amountInBase / Number(to.conversion.rateToBase);
+
+    return converted.toFixed(to.decimals);
+  }
+
+  formatAmount(amount: string | number, code?: string | null) {
+    const config = this.getConfig(code);
+    const rawAmount = typeof amount === 'string' ? amount : amount.toString();
+    const numericAmount = Number(rawAmount);
+
+    if (!Number.isFinite(numericAmount)) {
+      return {
+        raw: rawAmount,
+        formatted: 'Invalid Amount',
+        display: 'Invalid Amount',
+        symbol: config.stellarAssetCode,
+        decimals: config.decimals,
+      };
+    }
+
+    const formatted = this.formatNumber(numericAmount, config.decimals);
+    return {
+      raw: rawAmount,
+      numeric: numericAmount,
+      formatted,
+      display:
+        config.symbol === '$' || config.symbol === 'EUR'
+          ? `${config.symbol}${formatted}`
+          : `${formatted} ${config.symbol}`,
+      symbol: config.stellarAssetCode,
+      decimals: config.decimals,
+      currencyCode: config.code,
+    };
+  }
+
+  private formatNumber(amount: number, decimals: number): string {
+    if (amount >= 1) return amount.toFixed(2);
+    if (amount > 0) return amount.toFixed(decimals).replace(/\.?0+$/, '');
+    return amount.toFixed(2);
+  }
+
+  private loadCurrencyConfigs(): Record<CurrencyCode, CurrencyConfig> {
+    const configured = this.configService.get<string>('currency.configJson');
+    if (!configured) return DEFAULT_CURRENCY_CONFIGS;
+
+    try {
+      const parsed = JSON.parse(configured) as Partial<
+        Record<CurrencyCode, Partial<CurrencyConfig>>
+      >;
+
+      return Object.entries(DEFAULT_CURRENCY_CONFIGS).reduce(
+        (acc, [code, defaults]) => ({
+          ...acc,
+          [code]: {
+            ...defaults,
+            ...(parsed[code as CurrencyCode] || {}),
+            validation: {
+              ...defaults.validation,
+              ...(parsed[code as CurrencyCode]?.validation || {}),
+            },
+            conversion: {
+              ...defaults.conversion,
+              ...(parsed[code as CurrencyCode]?.conversion || {}),
+            },
+          },
+        }),
+        {} as Record<CurrencyCode, CurrencyConfig>,
+      );
+    } catch {
+      return DEFAULT_CURRENCY_CONFIGS;
+    }
+  }
+}

--- a/backend/src/modules/currency/currency.types.ts
+++ b/backend/src/modules/currency/currency.types.ts
@@ -1,0 +1,33 @@
+export enum CurrencyCode {
+  USDC = 'USDC',
+  USDT = 'USDT',
+  XLM = 'XLM',
+  EURC = 'EURC',
+}
+
+export interface CurrencyConfig {
+  code: CurrencyCode;
+  displayName: string;
+  symbol: string;
+  decimals: number;
+  type: 'native' | 'stablecoin';
+  stellarAssetCode: string;
+  issuer?: string | null;
+  contractId?: string | null;
+  enabled: boolean;
+  validation: {
+    minAmount: string;
+    maxDecimalPlaces: number;
+  };
+  conversion: {
+    baseCurrency: CurrencyCode;
+    rateToBase: string;
+  };
+}
+
+export interface NormalizedCurrencyAmount {
+  amount: string;
+  currencyCode: CurrencyCode;
+  amountBaseCurrency: string;
+  conversionRateToBase: string;
+}

--- a/backend/src/modules/savings/entities/savings-product.entity.ts
+++ b/backend/src/modules/savings/entities/savings-product.entity.ts
@@ -42,6 +42,9 @@ export class SavingsProduct {
   @Column('decimal', { precision: 14, scale: 2 })
   maxAmount: number;
 
+  @Column({ type: 'varchar', length: 12, default: 'USDC' })
+  currencyCode: string;
+
   @Column('int', { nullable: true })
   tenureMonths: number | null;
 

--- a/backend/src/modules/savings/entities/user-subscription.entity.ts
+++ b/backend/src/modules/savings/entities/user-subscription.entity.ts
@@ -29,6 +29,9 @@ export class UserSubscription {
   @Column('decimal', { precision: 14, scale: 2 })
   amount: number;
 
+  @Column({ type: 'varchar', length: 12, default: 'USDC' })
+  currencyCode: string;
+
   @Column({
     type: 'enum',
     enum: SubscriptionStatus,

--- a/backend/src/modules/transactions/dto/transaction-query.dto.ts
+++ b/backend/src/modules/transactions/dto/transaction-query.dto.ts
@@ -9,6 +9,7 @@ import {
 } from 'class-validator';
 import { PageOptionsDto } from '../../../common/dto/page-options.dto';
 import { LedgerTransactionType } from '../../blockchain/entities/transaction.entity';
+import { CurrencyCode } from '../../currency/currency.types';
 
 export class TransactionQueryDto extends PageOptionsDto {
   @ApiPropertyOptional({
@@ -78,4 +79,13 @@ export class TransactionQueryDto extends PageOptionsDto {
   @IsArray()
   @IsString({ each: true })
   readonly tags?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Filter by currency code',
+    example: 'USDC',
+    enum: CurrencyCode,
+  })
+  @IsOptional()
+  @IsEnum(CurrencyCode)
+  readonly currencyCode?: CurrencyCode;
 }

--- a/backend/src/modules/transactions/dto/transaction-response.dto.ts
+++ b/backend/src/modules/transactions/dto/transaction-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { LedgerTransactionType } from '../../blockchain/entities/transaction.entity';
+import { CurrencyCode } from '../../currency/currency.types';
 
 export class TransactionResponseDto {
   @ApiProperty({ description: 'Transaction ID' })
@@ -16,6 +17,27 @@ export class TransactionResponseDto {
 
   @ApiProperty({ description: 'Transaction amount (raw decimal string)' })
   amount: string;
+
+  @ApiProperty({
+    description: 'Currency code used for the transaction',
+    enum: CurrencyCode,
+    example: CurrencyCode.USDC,
+  })
+  currencyCode: CurrencyCode | string;
+
+  @ApiProperty({
+    description: 'Amount converted to the configured base currency',
+    nullable: true,
+    example: '100.0000000',
+  })
+  amountBaseCurrency: string | null;
+
+  @ApiProperty({
+    description: 'Conversion rate from transaction currency to base currency',
+    nullable: true,
+    example: '1',
+  })
+  conversionRateToBase: string | null;
 
   @ApiProperty({
     description: 'Formatted amount with currency symbol and proper decimals',
@@ -72,6 +94,12 @@ export class TransactionResponseDto {
     example: 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA',
   })
   assetId: string;
+
+  @ApiProperty({ description: 'Stellar asset code', nullable: true })
+  assetCode?: string | null;
+
+  @ApiProperty({ description: 'Stellar asset issuer', nullable: true })
+  assetIssuer?: string | null;
 
   @ApiProperty({ description: 'Additional metadata', nullable: true })
   metadata: Record<string, unknown> | null;

--- a/backend/src/modules/transactions/entities/transaction.entity.ts
+++ b/backend/src/modules/transactions/entities/transaction.entity.ts
@@ -44,6 +44,25 @@ export class Transaction extends BaseEntity {
   @Column('decimal', { precision: 18, scale: 7 })
   amount: string;
 
+  @Index('idx_transactions_currency_code')
+  @Column({ type: 'varchar', length: 12, default: 'USDC' })
+  currencyCode: string;
+
+  @Column({ type: 'varchar', length: 12, nullable: true })
+  assetCode: string | null;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  assetIssuer: string | null;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  assetContractId: string | null;
+
+  @Column('decimal', { precision: 18, scale: 7, nullable: true })
+  amountBaseCurrency: string | null;
+
+  @Column('decimal', { precision: 18, scale: 7, nullable: true })
+  conversionRateToBase: string | null;
+
   @Column({ type: 'varchar' })
   txHash?: string | null;
 

--- a/backend/src/modules/transactions/transactions.module.ts
+++ b/backend/src/modules/transactions/transactions.module.ts
@@ -6,9 +6,10 @@ import { TransactionsService } from './transactions.service';
 import { AutoCategorizationService } from './auto-categorization.service';
 import { LedgerTransaction } from '../blockchain/entities/transaction.entity';
 import { TransactionFormattingInterceptor } from '../../common/interceptors/transaction-formatting.interceptor';
+import { CurrencyModule } from '../currency/currency.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LedgerTransaction])],
+  imports: [TypeOrmModule.forFeature([LedgerTransaction]), CurrencyModule],
   controllers: [TransactionsController],
   providers: [
     TransactionsService,

--- a/backend/src/modules/transactions/transactions.service.spec.ts
+++ b/backend/src/modules/transactions/transactions.service.spec.ts
@@ -8,6 +8,8 @@ import {
 } from '../blockchain/entities/transaction.entity';
 import { TransactionQueryDto } from './dto/transaction-query.dto';
 import { Order } from '../../common/dto/page-options.dto';
+import { CurrencyService } from '../currency/currency.service';
+import { CurrencyCode } from '../currency/currency.types';
 
 describe('TransactionsService', () => {
   let service: TransactionsService;
@@ -26,6 +28,22 @@ describe('TransactionsService', () => {
     createQueryBuilder: jest.fn(() => mockQueryBuilder),
   };
 
+  const mockCurrencyService = {
+    resolveCurrencyFromAsset: jest.fn().mockReturnValue({
+      code: CurrencyCode.USDC,
+      stellarAssetCode: 'USDC',
+      issuer: null,
+      contractId: 'usdc-contract',
+      conversion: { rateToBase: '1' },
+    }),
+    normalizeAmount: jest.fn().mockReturnValue({
+      amount: '100.50',
+      currencyCode: CurrencyCode.USDC,
+      amountBaseCurrency: '100.5000000',
+      conversionRateToBase: '1',
+    }),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -33,6 +51,10 @@ describe('TransactionsService', () => {
         {
           provide: getRepositoryToken(LedgerTransaction),
           useValue: mockRepository,
+        },
+        {
+          provide: CurrencyService,
+          useValue: mockCurrencyService,
         },
       ],
     }).compile();

--- a/backend/src/modules/transactions/transactions.service.ts
+++ b/backend/src/modules/transactions/transactions.service.ts
@@ -8,12 +8,14 @@ import { TransactionQueryDto } from './dto/transaction-query.dto';
 import { TransactionResponseDto } from './dto/transaction-response.dto';
 import { PageDto } from '../../common/dto/page.dto';
 import { PageMetaDto } from '../../common/dto/page-meta.dto';
+import { CurrencyService } from '../currency/currency.service';
 
 @Injectable()
 export class TransactionsService {
   constructor(
     @InjectRepository(LedgerTransaction)
     private readonly transactionRepository: Repository<LedgerTransaction>,
+    private readonly currencyService: CurrencyService,
   ) {}
 
   async findAllForUser(
@@ -68,6 +70,9 @@ export class TransactionsService {
               userId: dto.userId,
               type: dto.type,
               amount: dto.amount,
+              currencyCode: dto.currencyCode,
+              amountBaseCurrency: dto.amountBaseCurrency ?? '',
+              conversionRateToBase: dto.conversionRateToBase ?? '',
               amountFormatted: dto.amountFormatted?.display ?? '',
               publicKey: dto.publicKey ?? '',
               eventId: dto.eventId,
@@ -77,6 +82,8 @@ export class TransactionsService {
               ledgerSequence: dto.ledgerSequence ?? '',
               poolId: dto.poolId ?? '',
               assetId: dto.assetId ?? '',
+              assetCode: dto.assetCode ?? '',
+              assetIssuer: dto.assetIssuer ?? '',
               metadata: dto.metadata ? JSON.stringify(dto.metadata) : '',
               createdAt: dto.createdAt,
             });
@@ -136,6 +143,12 @@ export class TransactionsService {
       });
     }
 
+    if (queryDto.currencyCode) {
+      queryBuilder.andWhere('transaction.currencyCode = :currencyCode', {
+        currencyCode: queryDto.currencyCode,
+      });
+    }
+
     // Filter by tags (any overlap)
     if (queryDto.tags && queryDto.tags.length > 0) {
       // Use Postgres array overlap operator (&&)
@@ -155,14 +168,34 @@ export class TransactionsService {
   ): TransactionResponseDto {
     const createdAt = new Date(transaction.createdAt);
 
-    // Extract asset ID from metadata or use default USDC
-    const assetId = this.extractAssetId(transaction);
+    const currency = this.currencyService.resolveCurrencyFromAsset({
+      currencyCode: transaction.currencyCode,
+      assetCode: transaction.assetCode,
+      assetContractId:
+        transaction.assetContractId ?? this.extractAssetId(transaction),
+    });
+
+    const normalized =
+      Number(transaction.amount) > 0
+        ? this.currencyService.normalizeAmount(
+            transaction.amount,
+            currency.code,
+          )
+        : {
+            amountBaseCurrency: transaction.amount,
+            conversionRateToBase: currency.conversion.rateToBase,
+          };
 
     return {
       id: transaction.id,
       userId: transaction.userId,
       type: transaction.type,
       amount: transaction.amount,
+      currencyCode: currency.code,
+      amountBaseCurrency:
+        transaction.amountBaseCurrency ?? normalized.amountBaseCurrency,
+      conversionRateToBase:
+        transaction.conversionRateToBase ?? normalized.conversionRateToBase,
       publicKey: transaction.publicKey,
       eventId: transaction.eventId,
       transactionHash: transaction.transactionHash,
@@ -183,7 +216,12 @@ export class TransactionsService {
         second: '2-digit',
       }),
       // Add assetId for interceptor formatting (will be enriched by interceptor)
-      assetId,
+      assetId:
+        transaction.assetContractId ??
+        currency.contractId ??
+        this.extractAssetId(transaction),
+      assetCode: transaction.assetCode ?? currency.stellarAssetCode,
+      assetIssuer: transaction.assetIssuer ?? currency.issuer ?? null,
     } as TransactionResponseDto;
   }
 
@@ -273,6 +311,10 @@ export class TransactionsService {
    * Extract asset ID from transaction metadata or return default
    */
   private extractAssetId(transaction: LedgerTransaction): string {
+    if (transaction.assetContractId) {
+      return transaction.assetContractId;
+    }
+
     // Check metadata for asset information
     if (transaction.metadata?.assetId) {
       return transaction.metadata.assetId as string;


### PR DESCRIPTION
Summary
- Adds a backend currency abstraction layer to prepare Nestera for USDC, USDT, XLM, and EUR stablecoin support.
- Adds currency configuration, validation, conversion, transaction metadata, and migration support while preserving USDC defaults for existing records/events.

Issue
- Closes #909

Changes
- Added a CurrencyModule with currency definitions, configuration override support, amount validation, formatting, and base-currency conversion helpers.
- Added GET /currencies to expose supported currency metadata for clients and integrations.
- Added multi-currency columns to transactions, savings products, and user subscriptions through a reversible TypeORM migration.
- Extended transaction DTOs, CSV export, query filtering, and response transformation with currency code, asset metadata, base-currency amount, and conversion rate fields.
- Updated deposit, withdraw, and yield event handlers to resolve currency metadata from event payloads and persist normalized transaction values.
- Updated transaction formatting to use currency-aware formatting when a transaction currency is present.
- Replaced USDC-only amount validation with a currency-aware validator while preserving the existing IsUSDCAmount export.
- Updated OpenAPI generation text and .env.example for currency configuration.

Validation
- Ran `git diff --check`.
- Ran `npx.cmd --yes prettier@3.8.1 --check` on all touched backend TypeScript files.
- Attempted `pnpm.cmd install --frozen-lockfile` in backend; failed because the workspace pnpm lockfile is already out of sync with frontend/package.json.
- Attempted `npm.cmd install --package-lock=false --no-audit --no-fund` in backend; failed on an existing peer dependency conflict between Nest 11 and @nestjs/schedule@3.
- Attempted `npm.cmd install --package-lock=false --no-audit --no-fund --legacy-peer-deps` in backend; timed out before creating backend/node_modules.
- Attempted `pnpm.cmd --filter backend install --no-frozen-lockfile`; timed out before creating node_modules.
- TypeScript build/tests were not run because dependency installation did not complete.

Notes
- Fork verification: kitWarse/Nestera is a fork of Devsol-01/Nestera.
- Push to kitWarse/Nestera failed with 403 for the logged-in account utahkanz-ops, so the branch was pushed to a newly created accessible fork: utahkanz-ops/Nestera.
- No lockfiles were modified.