### PR TITLE
feat(api): add OpenAPI/Swagger documentation (#902)

### DIFF
--- a/backend/src/common/decorators/api-common-responses.decorator.ts
+++ b/backend/src/common/decorators/api-common-responses.decorator.ts
@@ -1,0 +1,105 @@
+import { applyDecorators, HttpStatus } from '@nestjs/common';
+import { ApiResponse } from '@nestjs/swagger';
+
+/** Standard 401 Unauthorized response */
+export const ApiUnauthorized = () =>
+  ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Missing or invalid JWT token',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+        timestamp: '2026-06-01T00:00:00.000Z',
+      },
+    },
+  });
+
+/** Standard 403 Forbidden response */
+export const ApiForbidden = () =>
+  ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Insufficient permissions',
+    schema: {
+      example: {
+        statusCode: 403,
+        message: 'Forbidden resource',
+        timestamp: '2026-06-01T00:00:00.000Z',
+      },
+    },
+  });
+
+/** Standard 404 Not Found response */
+export const ApiNotFound = (resource = 'Resource') =>
+  ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: `${resource} not found`,
+    schema: {
+      example: {
+        statusCode: 404,
+        message: `${resource} not found`,
+        timestamp: '2026-06-01T00:00:00.000Z',
+      },
+    },
+  });
+
+/** Standard 422 / 400 Validation error */
+export const ApiBadRequest = (message = 'Validation failed') =>
+  ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: message,
+    schema: {
+      example: {
+        statusCode: 400,
+        message,
+        timestamp: '2026-06-01T00:00:00.000Z',
+      },
+    },
+  });
+
+/** Standard 429 Too Many Requests response */
+export const ApiTooManyRequests = () =>
+  ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description:
+      'Rate limit exceeded. Default limits: 100 req/min (general), 5 req/15 min (auth), 10 req/min (RPC-heavy).',
+    schema: {
+      example: {
+        statusCode: 429,
+        message: 'ThrottlerException: Too Many Requests',
+        timestamp: '2026-06-01T00:00:00.000Z',
+      },
+    },
+  });
+
+/** Standard 500 Internal Server Error */
+export const ApiInternalError = () =>
+  ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: 'Internal server error',
+    schema: {
+      example: {
+        statusCode: 500,
+        message: 'Internal server error',
+        timestamp: '2026-06-01T00:00:00.000Z',
+      },
+    },
+  });
+
+/**
+ * Bundle of common error responses for authenticated endpoints:
+ * 401, 429, 500
+ */
+export const ApiAuthResponses = () =>
+  applyDecorators(ApiUnauthorized(), ApiTooManyRequests(), ApiInternalError());
+
+/**
+ * Bundle for admin-only endpoints: 401, 403, 429, 500
+ */
+export const ApiAdminResponses = () =>
+  applyDecorators(
+    ApiUnauthorized(),
+    ApiForbidden(),
+    ApiTooManyRequests(),
+    ApiInternalError(),
+  );

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -42,25 +42,90 @@ async function bootstrap() {
     }),
   );
 
-  // Swagger setup — one document per supported version
+  // Swagger setup — one document per supported version + canonical /api/docs
+  const swaggerBearerAuth = {
+    type: 'http' as const,
+    scheme: 'bearer',
+    bearerFormat: 'JWT',
+    description:
+      'Enter the JWT access token returned by POST /api/v2/auth/login or POST /api/v2/auth/verify-signature.',
+  };
+
+  const sharedDescription = [
+    '## Authentication',
+    'Most endpoints require a Bearer JWT. Obtain one via:',
+    '- `POST /api/v2/auth/login` — email/password',
+    '- `POST /api/v2/auth/verify-signature` — Stellar wallet signature',
+    '',
+    '## Rate Limiting',
+    '| Tier | Limit | Window | Applies to |',
+    '|------|-------|--------|------------|',
+    '| `general` | 100 req | 1 min | All routes |',
+    '| `auth` | 5 req | 15 min | Login, register, nonce, verify |',
+    '| `rpc` | 10–30 req | 1 min | On-chain read routes |',
+    '',
+    'Rate-limited responses return **HTTP 429** with a `Retry-After` header.',
+    '',
+    '## Common Error Responses',
+    '| Status | Meaning |',
+    '|--------|---------|',
+    '| 400 | Validation failure — check the `message` array |',
+    '| 401 | Missing or invalid JWT |',
+    '| 403 | Insufficient role (admin routes) |',
+    '| 404 | Resource not found |',
+    '| 429 | Rate limit exceeded |',
+    '| 500 | Internal server error |',
+  ].join('\n');
+
   for (const version of ['1', '2']) {
+    const isDeprecated = version === '1';
     const swaggerConfig = new DocumentBuilder()
-      .setTitle(`Nestera API v${version}`)
+      .setTitle('Nestera API')
       .setDescription(
-        version === '1'
-          ? 'API v1 — DEPRECATED. Sunset: 2026-09-01. Migrate to v2.'
-          : 'API v2 — Current stable version.',
+        `${isDeprecated ? '**⚠️ v1 is DEPRECATED — Sunset: 2026-09-01. Please migrate to v2.**\n\n' : ''}${sharedDescription}`,
       )
       .setVersion(version)
-      .addBearerAuth()
+      .setContact('Nestera Team', 'https://github.com/Devsol-01/Nestera', '')
+      .setLicense('MIT', 'https://opensource.org/licenses/MIT')
+      .addBearerAuth(swaggerBearerAuth)
+      .addTag('auth', 'Authentication — register, login, 2FA, wallet linking')
+      .addTag(
+        'savings',
+        'Savings products, subscriptions, goals, auto-deposits',
+      )
+      .addTag('users', 'User profile, avatar, KYC documents, net worth')
+      .addTag('Transactions', 'Transaction history, CSV export, tagging')
+      .addTag(
+        'analytics',
+        'Portfolio timeline, asset allocation, yield breakdown',
+      )
+      .addTag('notifications', 'In-app notifications and preferences')
+      .addTag('referrals', 'Referral codes and stats')
+      .addTag('rewards', 'Leaderboards and reward visibility')
+      .addTag('governance', 'Voting power, delegation')
+      .addTag('kyc', 'KYC verification flow and compliance')
+      .addTag('claims', 'Medical claims submission and verification')
+      .addTag('disputes', 'Dispute creation and resolution')
+      .addTag(
+        'Blockchain',
+        'Stellar on-chain data, wallet generation, RPC status',
+      )
+      .addTag('admin', 'Admin-only user and KYC management')
       .build();
+
     const document = SwaggerModule.createDocument(app, swaggerConfig);
     SwaggerModule.setup(`api/v${version}/docs`, app, document);
+
+    // Canonical /api/docs always points to v2
+    if (version === '2') {
+      SwaggerModule.setup('api/docs', app, document);
+    }
   }
 
   const server = await app.listen(port || 3001);
   const logger = app.get(Logger);
   logger.log(`Application is running on: http://localhost:${port}/api`);
+  logger.log(`Swagger docs (canonical): http://localhost:${port}/api/docs`);
   logger.log(
     `Swagger v1 docs (deprecated): http://localhost:${port}/api/v1/docs`,
   );

--- a/backend/src/modules/admin/admin-waitlist.controller.ts
+++ b/backend/src/modules/admin/admin-waitlist.controller.ts
@@ -11,7 +11,15 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
@@ -37,6 +45,13 @@ export class AdminWaitlistController {
   ) {}
 
   @Get(':productId')
+  @ApiOperation({ summary: 'List waitlist entries for a product (admin)' })
+  @ApiParam({ name: 'productId', type: 'string' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated waitlist entries' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async listForProduct(
     @Param('productId') productId: string,
     @Query('page', ParseIntPipe) page = 1,
@@ -53,6 +68,13 @@ export class AdminWaitlistController {
   }
 
   @Post(':productId/entries/:entryId/promote')
+  @ApiOperation({ summary: 'Promote a waitlist entry (admin)' })
+  @ApiParam({ name: 'productId', type: 'string' })
+  @ApiParam({ name: 'entryId', type: 'string' })
+  @ApiBody({ schema: { example: { priority: 10 } } })
+  @ApiResponse({ status: 201, description: 'Entry promoted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async promoteEntry(
     @Param('productId') productId: string,
     @Param('entryId') entryId: string,
@@ -71,6 +93,12 @@ export class AdminWaitlistController {
 
   @Delete(':productId/entries/:entryId')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a waitlist entry (admin)' })
+  @ApiParam({ name: 'productId', type: 'string' })
+  @ApiParam({ name: 'entryId', type: 'string' })
+  @ApiResponse({ status: 204, description: 'Entry removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async removeEntry(
     @Param('productId') productId: string,
     @Param('entryId') entryId: string,
@@ -81,6 +109,14 @@ export class AdminWaitlistController {
   }
 
   @Post(':productId/release')
+  @ApiOperation({
+    summary: 'Release spots on a waitlist and notify users (admin)',
+  })
+  @ApiParam({ name: 'productId', type: 'string' })
+  @ApiBody({ schema: { example: { spots: 5 } } })
+  @ApiResponse({ status: 201, description: 'Spots released' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async releaseSpots(
     @Param('productId') productId: string,
     @Body() body: { spots?: number },
@@ -91,6 +127,11 @@ export class AdminWaitlistController {
   }
 
   @Get(':productId/analytics')
+  @ApiOperation({ summary: 'Get waitlist analytics for a product (admin)' })
+  @ApiParam({ name: 'productId', type: 'string' })
+  @ApiResponse({ status: 200, description: 'Waitlist analytics' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async analyticsForProduct(@Param('productId') productId: string) {
     const waitlistSize = await this.waitlistRepo.count({
       where: { productId, notifiedAt: IsNull() },

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -11,7 +11,9 @@ import {
 import {
   ApiTags,
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
+  ApiParam,
   ApiResponse,
 } from '@nestjs/swagger';
 import { UserService } from '../user/user.service';
@@ -34,6 +36,17 @@ export class AdminController {
   ) {}
 
   @Patch('users/:id/kyc/approve')
+  @ApiOperation({ summary: 'Approve KYC for a user (admin only)' })
+  @ApiParam({
+    name: 'id',
+    type: 'string',
+    format: 'uuid',
+    description: 'User ID',
+  })
+  @ApiResponse({ status: 200, description: 'KYC approved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async approveKyc(@Param('id') userId: string) {
     if (!userId) {
       throw new BadRequestException('User ID is required');
@@ -42,6 +55,18 @@ export class AdminController {
   }
 
   @Patch('users/:id/kyc/reject')
+  @ApiOperation({ summary: 'Reject KYC for a user with a reason (admin only)' })
+  @ApiParam({
+    name: 'id',
+    type: 'string',
+    format: 'uuid',
+    description: 'User ID',
+  })
+  @ApiBody({ type: RejectKycDto })
+  @ApiResponse({ status: 200, description: 'KYC rejected' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async rejectKyc(@Param('id') userId: string, @Body() dto: RejectKycDto) {
     if (!userId) {
       throw new BadRequestException('User ID is required');
@@ -53,6 +78,38 @@ export class AdminController {
   }
 
   @Patch('users/:id/kyc')
+  @ApiOperation({
+    summary: 'Approve or reject KYC in a single call (admin only)',
+  })
+  @ApiParam({
+    name: 'id',
+    type: 'string',
+    format: 'uuid',
+    description: 'User ID',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['action'],
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['approve', 'reject'],
+          example: 'approve',
+        },
+        reason: {
+          type: 'string',
+          example: 'Document mismatch',
+          description: 'Required when action is reject',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'KYC status updated' })
+  @ApiResponse({ status: 400, description: 'Invalid action or missing reason' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async updateKycStatus(
     @Param('id') userId: string,
     @Body() body: { action: 'approve' | 'reject'; reason?: string },

--- a/backend/src/modules/analytics/analytics.controller.ts
+++ b/backend/src/modules/analytics/analytics.controller.ts
@@ -104,11 +104,14 @@ export class AnalyticsController {
   @Get('rebalancing-suggestions')
   @ApiOperation({
     summary: 'Get risk-adjusted portfolio rebalancing suggestions',
+    description:
+      'Returns recommendations for rebalancing based on the selected risk profile (conservative, balanced, aggressive).',
   })
   @ApiResponse({
     status: 200,
     description: 'Rebalancing recommendation payload',
   })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getRebalancingSuggestions(
     @CurrentUser() user: { id: string },
     @Query() query: RebalancingQueryDto,

--- a/backend/src/modules/blockchain/blockchain.controller.ts
+++ b/backend/src/modules/blockchain/blockchain.controller.ts
@@ -14,6 +14,10 @@ export class BlockchainController {
 
   @Post('wallets/generate')
   @ApiOperation({ summary: 'Generate a new Stellar keypair' })
+  @ApiResponse({
+    status: 201,
+    description: 'New Stellar keypair (publicKey + secretKey)',
+  })
   generateWallet() {
     return this.stellarService.generateKeypair();
   }

--- a/backend/src/modules/governance/governance.controller.ts
+++ b/backend/src/modules/governance/governance.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Delete, Get, Post, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -32,6 +33,7 @@ export class GovernanceController {
     description: 'Delegation lookup result',
     type: DelegationResponseDto,
   })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getDelegation(
     @CurrentUser() user: { id: string },
   ): Promise<DelegationResponseDto> {
@@ -49,6 +51,7 @@ export class GovernanceController {
     description: 'Voting power lookup result',
     type: VotingPowerResponseDto,
   })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getVotingPower(
     @CurrentUser() user: { id: string },
   ): Promise<VotingPowerResponseDto> {
@@ -59,6 +62,7 @@ export class GovernanceController {
 
   @Post('governance/delegate')
   @ApiOperation({ summary: 'Delegate voting power to a trusted address' })
+  @ApiBody({ type: DelegateVoteDto })
   @ApiResponse({
     status: 201,
     description: 'Delegation set',
@@ -68,6 +72,7 @@ export class GovernanceController {
     },
   })
   @ApiResponse({ status: 400, description: 'Loop detected or invalid address' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   delegate(
     @CurrentUser() user: { id: string },
     @Body() dto: DelegateVoteDto,
@@ -78,6 +83,7 @@ export class GovernanceController {
   @Delete('governance/delegate')
   @ApiOperation({ summary: 'Revoke current voting power delegation' })
   @ApiResponse({ status: 200, description: 'Delegation revoked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   revokeDelegate(@CurrentUser() user: { id: string }): Promise<void> {
     return this.governanceService.revokeDelegate(user.id);
   }
@@ -97,6 +103,7 @@ export class GovernanceController {
       },
     },
   })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getMyDelegation(
     @CurrentUser() user: { id: string },
   ): Promise<{ delegate: string | null; totalDelegatedPower: number }> {
@@ -116,6 +123,7 @@ export class GovernanceController {
       },
     },
   })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getMyDelegators(
     @CurrentUser() user: { id: string },
   ): Promise<{ delegators: string[]; totalDelegatedPower: number }> {

--- a/backend/src/modules/kyc/kyc.controller.ts
+++ b/backend/src/modules/kyc/kyc.controller.ts
@@ -10,7 +10,9 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -34,12 +36,14 @@ export class KycController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Initiate third-party KYC verification' })
   @ApiResponse({ status: 201, description: 'KYC initiated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   initiate(@CurrentUser() user: { id: string }, @Body() dto: InitiateKycDto) {
     return this.kycService.initiateVerification(user.id, dto);
   }
 
   @Post('webhooks/kyc/status')
   @ApiOperation({ summary: 'Handle KYC provider webhook status updates' })
+  @ApiBody({ type: KycWebhookDto })
   @ApiResponse({ status: 201, description: 'Webhook processed' })
   handleStatusWebhook(@Body() dto: KycWebhookDto, @Req() req: Request) {
     return this.kycService.handleWebhook(dto, req.body);
@@ -49,6 +53,8 @@ export class KycController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'List current user KYC verification records' })
+  @ApiResponse({ status: 200, description: 'User KYC verification records' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getMyVerifications(@CurrentUser() user: { id: string }) {
     return this.kycService.listUserVerifications(user.id);
   }
@@ -58,6 +64,21 @@ export class KycController {
   @Roles(Role.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Generate compliance report for regulators' })
+  @ApiQuery({
+    name: 'regulator',
+    required: false,
+    type: String,
+    example: 'fincen',
+  })
+  @ApiQuery({
+    name: 'period',
+    required: false,
+    type: String,
+    example: 'current-month',
+  })
+  @ApiResponse({ status: 200, description: 'Compliance report' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin role required' })
   getComplianceReport(
     @Query('regulator') regulator: string,
     @Query('period') period: string,

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -9,7 +9,15 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { NotificationsService } from './notifications.service';
@@ -25,6 +33,10 @@ export class NotificationsController {
 
   @Get()
   @ApiOperation({ summary: 'Get user notifications' })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiResponse({ status: 200, description: 'Paginated notifications list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getNotifications(
     @CurrentUser() user: User,
     @Query('page') page: number = 1,
@@ -39,6 +51,12 @@ export class NotificationsController {
 
   @Get('unread-count')
   @ApiOperation({ summary: 'Get unread notification count' })
+  @ApiResponse({
+    status: 200,
+    description: 'Unread count',
+    schema: { example: { unreadCount: 3 } },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getUnreadCount(@CurrentUser() user: User) {
     const count = await this.notificationsService.getUnreadCount(user.id);
     return { unreadCount: count };
@@ -47,6 +65,10 @@ export class NotificationsController {
   @Patch(':id/read')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Mark notification as read' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Notification marked as read' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Notification not found' })
   async markAsRead(@Param('id') notificationId: string) {
     return await this.notificationsService.markAsRead(notificationId);
   }
@@ -54,6 +76,8 @@ export class NotificationsController {
   @Patch('mark-all-read')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Mark all notifications as read' })
+  @ApiResponse({ status: 200, description: 'All notifications marked as read' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async markAllAsRead(@CurrentUser() user: User) {
     await this.notificationsService.markAllAsRead(user.id);
     return { message: 'All notifications marked as read' };
@@ -61,6 +85,8 @@ export class NotificationsController {
 
   @Get('preferences')
   @ApiOperation({ summary: 'Get notification preferences' })
+  @ApiResponse({ status: 200, description: 'Notification preferences' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getPreferences(@CurrentUser() user: User) {
     return await this.notificationsService.getOrCreatePreferences(user.id);
   }
@@ -70,6 +96,10 @@ export class NotificationsController {
     summary:
       'Update notification preferences (channels, types, quiet hours, digest)',
   })
+  @ApiBody({ type: UpdateNotificationPreferenceDto })
+  @ApiResponse({ status: 200, description: 'Preferences updated' })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async updatePreferences(
     @CurrentUser() user: User,
     @Body() updateDto: UpdateNotificationPreferenceDto,

--- a/backend/src/modules/notifications/user-notifications.controller.ts
+++ b/backend/src/modules/notifications/user-notifications.controller.ts
@@ -1,5 +1,11 @@
 import { Controller, Get, Patch, Body, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { NotificationsService } from './notifications.service';
@@ -15,6 +21,8 @@ export class UserNotificationsController {
 
   @Get('preferences')
   @ApiOperation({ summary: 'Get all notification preference settings' })
+  @ApiResponse({ status: 200, description: 'Notification preferences' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getPreferences(@CurrentUser() user: User) {
     return this.notificationsService.getOrCreatePreferences(user.id);
   }
@@ -24,6 +32,9 @@ export class UserNotificationsController {
     summary:
       'Update notification preferences (channels, types, quiet hours, digest frequency)',
   })
+  @ApiBody({ type: UpdateNotificationPreferenceDto })
+  @ApiResponse({ status: 200, description: 'Preferences updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   updatePreferences(
     @CurrentUser() user: User,
     @Body() dto: UpdateNotificationPreferenceDto,

--- a/backend/src/modules/referrals/referrals.controller.ts
+++ b/backend/src/modules/referrals/referrals.controller.ts
@@ -12,6 +12,7 @@ import {
   ApiTags,
   ApiOperation,
   ApiResponse,
+  ApiBody,
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
@@ -31,10 +32,19 @@ export class ReferralsController {
 
   @Post('generate')
   @ApiOperation({ summary: 'Generate a referral code for the current user' })
+  @ApiBody({ type: CreateReferralDto })
   @ApiResponse({
     status: 201,
     description: 'Referral code generated successfully',
+    schema: {
+      example: {
+        referralCode: 'ABC12345',
+        id: 'uuid',
+        createdAt: '2026-06-01T00:00:00.000Z',
+      },
+    },
   })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async generateReferralCode(@Request() req, @Body() dto: CreateReferralDto) {
     const referral = await this.referralsService.generateReferralCode(
       req.user.userId,
@@ -50,6 +60,7 @@ export class ReferralsController {
   @Get('stats')
   @ApiOperation({ summary: "Get current user's referral statistics" })
   @ApiResponse({ status: 200, type: ReferralStatsDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getReferralStats(@Request() req): Promise<ReferralStatsDto> {
     return this.referralsService.getReferralStats(req.user.userId);
   }
@@ -57,6 +68,7 @@ export class ReferralsController {
   @Get('my-referrals')
   @ApiOperation({ summary: 'Get list of users referred by current user' })
   @ApiResponse({ status: 200, type: [ReferralResponseDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMyReferrals(@Request() req) {
     const referrals = await this.referralsService.getUserReferrals(
       req.user.userId,
@@ -79,6 +91,9 @@ export class ReferralsController {
   @ApiOperation({
     summary: 'Internal: Check if referral should be completed after deposit',
   })
+  @ApiBody({ schema: { example: { userId: 'uuid', depositAmount: '100.00' } } })
+  @ApiResponse({ status: 200, description: 'Referral check completed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async checkReferralCompletion(
     @Body() body: { userId: string; depositAmount: string },
   ) {

--- a/backend/src/modules/rewards/rewards.controller.ts
+++ b/backend/src/modules/rewards/rewards.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Patch, Query, Body, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -69,7 +70,9 @@ export class RewardsController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update leaderboard visibility (privacy setting)' })
+  @ApiBody({ type: UpdateVisibilityDto })
   @ApiResponse({ status: 200, description: 'Visibility updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   updateVisibility(
     @CurrentUser() user: { id: string },
     @Body() dto: UpdateVisibilityDto,

--- a/backend/src/modules/savings/waitlist.controller.ts
+++ b/backend/src/modules/savings/waitlist.controller.ts
@@ -13,6 +13,7 @@ import {
   ApiBearerAuth,
   ApiParam,
   ApiOperation,
+  ApiResponse,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -29,6 +30,13 @@ export class WaitlistController {
   @ApiBearerAuth()
   @ApiParam({ name: 'id', description: 'Product UUID' })
   @ApiOperation({ summary: 'Join waitlist for a savings product' })
+  @ApiResponse({
+    status: 201,
+    description: 'Joined waitlist',
+    schema: { example: { id: 'uuid', position: 5 } },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 409, description: 'Already on waitlist' })
   async join(
     @Param('id') id: string,
     @CurrentUser() user: { id: string; email: string },
@@ -46,6 +54,9 @@ export class WaitlistController {
   @ApiBearerAuth()
   @ApiParam({ name: 'id', description: 'Product UUID' })
   @ApiOperation({ summary: 'Get current position on waitlist' })
+  @ApiResponse({ status: 200, description: 'Waitlist position' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Not on waitlist' })
   async getPosition(
     @Param('id') id: string,
     @CurrentUser() user: { id: string },
@@ -61,6 +72,9 @@ export class WaitlistController {
   @ApiBearerAuth()
   @ApiParam({ name: 'id', description: 'Product UUID' })
   @ApiOperation({ summary: 'Leave waitlist for a savings product' })
+  @ApiResponse({ status: 204, description: 'Left waitlist' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Not on waitlist' })
   async leaveWaitlist(
     @Param('id') id: string,
     @CurrentUser() user: { id: string },

--- a/backend/src/modules/transactions/transactions.controller.ts
+++ b/backend/src/modules/transactions/transactions.controller.ts
@@ -11,7 +11,9 @@ import {
 import { Response } from 'express';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -85,6 +87,17 @@ export class TransactionsController {
   }
 
   @Post(':id/tag')
+  @ApiOperation({ summary: 'Add or update a tag on a transaction' })
+  @ApiParam({
+    name: 'id',
+    type: 'string',
+    format: 'uuid',
+    description: 'Transaction ID',
+  })
+  @ApiBody({ type: TagTransactionDto })
+  @ApiResponse({ status: 201, description: 'Tag applied' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Transaction not found' })
   async tagTransaction(
     @CurrentUser() user: { id: string },
     @Param('id') id: string,
@@ -94,11 +107,21 @@ export class TransactionsController {
   }
 
   @Get('categories')
+  @ApiOperation({
+    summary: 'List distinct transaction categories for the current user',
+  })
+  @ApiResponse({ status: 200, description: 'List of category strings' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getCategories(@CurrentUser() user: { id: string }) {
     return this.transactionsService.listCategories(user.id);
   }
 
   @Post('tags/bulk')
+  @ApiOperation({ summary: 'Apply tags to multiple transactions at once' })
+  @ApiBody({ type: BulkTagDto })
+  @ApiResponse({ status: 201, description: 'Bulk tags applied' })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async bulkTag(@CurrentUser() user: { id: string }, @Body() body: BulkTagDto) {
     return this.transactionsService.bulkTag(user.id, body);
   }

--- a/backend/src/modules/user/dto/update-user.dto.ts
+++ b/backend/src/modules/user/dto/update-user.dto.ts
@@ -1,11 +1,14 @@
 import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateUserDto {
+  @ApiPropertyOptional({ example: 'Alice', maxLength: 100 })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   name?: string;
 
+  @ApiPropertyOptional({ example: 'Saving for the future.', maxLength: 500 })
   @IsOptional()
   @IsString()
   @MaxLength(500)
@@ -13,14 +16,17 @@ export class UpdateUserDto {
 }
 
 export class ApproveKycDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
   @IsString()
   userId: string;
 }
 
 export class RejectKycDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
   @IsString()
   userId: string;
 
+  @ApiProperty({ example: 'Document expired or unclear' })
   @IsString()
   reason: string;
 }

--- a/backend/src/modules/user/user.controller.ts
+++ b/backend/src/modules/user/user.controller.ts
@@ -18,7 +18,10 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -112,11 +115,24 @@ export class UserController {
 
   @Get('me')
   @ApiOperation({ summary: 'Get basic info for the authenticated user' })
+  @ApiResponse({ status: 200, description: 'User basic info' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getMe(@CurrentUser() user: { id: string }) {
     return this.userService.findById(user.id);
   }
 
   @Get('me/net-worth')
+  @ApiOperation({
+    summary: 'Get net worth breakdown for the authenticated user',
+    description:
+      'Returns wallet balance, flexible/locked savings, and percentage breakdown. Requires a linked Stellar public key.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Net worth data',
+    type: NetWorthDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getNetWorth(@CurrentUser() user: { id: string }): Promise<NetWorthDto> {
     const userEntity = await this.userService.findById(user.id);
 
@@ -162,22 +178,57 @@ export class UserController {
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a user by ID' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'User found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   findOne(@Param('id') id: string) {
     return this.userService.findById(id);
   }
 
   @Patch('me')
+  @ApiOperation({ summary: 'Update the authenticated user profile' })
+  @ApiBody({ type: UpdateUserDto })
+  @ApiResponse({ status: 200, description: 'Profile updated' })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   updateMe(@CurrentUser() user: { id: string }, @Body() dto: UpdateUserDto) {
     return this.userService.update(user.id, dto);
   }
 
   @Delete('me')
+  @ApiOperation({ summary: 'Delete the authenticated user account' })
+  @ApiResponse({ status: 200, description: 'Account deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   deleteMe(@CurrentUser() user: { id: string }) {
     return this.userService.remove(user.id);
   }
 
   @Post('avatar')
   @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({
+    summary: 'Upload a profile avatar image (JPEG/PNG/WebP, max 5 MB)',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'Image file (JPEG, PNG, WebP)',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Avatar updated' })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid file type or size exceeded',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async uploadAvatar(
     @CurrentUser() user: { id: string },
     @UploadedFile(
@@ -196,6 +247,28 @@ export class UserController {
 
   @Post('me/kyc-docs')
   @UseInterceptors(FileInterceptor('document'))
+  @ApiOperation({
+    summary: 'Upload a KYC identity document (PDF/JPEG, max 10 MB)',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        document: {
+          type: 'string',
+          format: 'binary',
+          description: 'KYC document (PDF or JPEG)',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'KYC document uploaded' })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid file type or size exceeded',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async uploadKycDocument(
     @CurrentUser() user: { id: string },
     @UploadedFile(

--- a/backend/src/modules/user/wallet.controller.ts
+++ b/backend/src/modules/user/wallet.controller.ts
@@ -11,7 +11,9 @@ import {
 import {
   ApiTags,
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
+  ApiParam,
   ApiResponse,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
@@ -30,7 +32,9 @@ export class WalletController {
   @ApiOperation({
     summary: 'Link a new Stellar wallet with signature verification',
   })
+  @ApiBody({ type: LinkWalletDto })
   @ApiResponse({ status: 201, description: 'Wallet linked successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 409, description: 'Wallet already linked' })
   linkWallet(@CurrentUser() user: { id: string }, @Body() dto: LinkWalletDto) {
     return this.walletService.linkWallet(user.id, dto);
@@ -38,7 +42,10 @@ export class WalletController {
 
   @Delete(':address/unlink')
   @ApiOperation({ summary: 'Unlink a wallet address' })
+  @ApiParam({ name: 'address', description: 'Stellar public key to unlink' })
   @ApiResponse({ status: 200, description: 'Wallet unlinked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Wallet not found' })
   async unlinkWallet(
     @CurrentUser() user: { id: string },
     @Param('address') address: string,
@@ -49,12 +56,21 @@ export class WalletController {
 
   @Get()
   @ApiOperation({ summary: 'List all linked wallets' })
+  @ApiResponse({ status: 200, description: 'List of linked wallets' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   listWallets(@CurrentUser() user: { id: string }) {
     return this.walletService.listWallets(user.id);
   }
 
   @Patch(':address/set-primary')
   @ApiOperation({ summary: 'Set a wallet as primary' })
+  @ApiParam({
+    name: 'address',
+    description: 'Stellar public key to set as primary',
+  })
+  @ApiResponse({ status: 200, description: 'Primary wallet updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Wallet not found' })
   setPrimary(
     @CurrentUser() user: { id: string },
     @Param('address') address: string,


### PR DESCRIPTION
- Host interactive docs at /api/docs (v2 canonical), /api/v1/docs, /api/v2/docs
- Add auth guide, rate limiting table, and error response table to Swagger description
- Add per-tag descriptions for all 13 API domains
- Add ApiCommonResponses decorator with reusable 401/403/404/429/500 helpers
- Add full @ApiOperation, @ApiResponse, @ApiBody, @ApiParam, @ApiQuery decorators to all controllers: auth, savings, analytics, transactions, users, wallets, admin, governance, referrals, notifications, rewards, kyc, blockchain, waitlist
- Add ApiProperty examples to UpdateUserDto, ApproveKycDto, RejectKycDto


closes #902 