### PR TITLE
feat: add comprehensive Swagger/OpenAPI documentation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.js"
+    "test:e2e": "jest --config ./test/jest-e2e.js",
+    "generate:openapi": "ts-node -r tsconfig-paths/register scripts/generate-openapi-spec.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1019.0",

--- a/backend/scripts/generate-openapi-spec.ts
+++ b/backend/scripts/generate-openapi-spec.ts
@@ -2,18 +2,20 @@
  * generate-openapi-spec.ts
  *
  * Bootstraps the NestJS app without listening on a port and dumps the
- * OpenAPI document to JSON and YAML files.
+ * OpenAPI document to JSON and YAML files for each supported API version.
  *
  * Usage:
  *   npx ts-node -r tsconfig-paths/register scripts/generate-openapi-spec.ts
  *
  * Output:
- *   openapi.json   — machine-readable spec (import into Postman, Insomnia, etc.)
- *   openapi.yaml   — human-readable spec
+ *   openapi-v2.json / openapi-v2.yaml  — v2 (current, stable)
+ *   openapi-v1.json / openapi-v1.yaml  — v1 (deprecated, sunset 2026-09-01)
+ *   openapi.json / openapi.yaml        — symlink/alias for v2 (backwards compat)
  */
 
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { VersioningType } from '@nestjs/common';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { AppModule } from '../src/app.module';
@@ -21,49 +23,124 @@ import { ValidationPipe } from '@nestjs/common';
 import { PageDto } from '../src/common/dto/page.dto';
 import { PageMetaDto } from '../src/common/dto/page-meta.dto';
 import { TransactionResponseDto } from '../src/modules/transactions/dto/transaction-response.dto';
+import {
+  VersioningMiddleware,
+  CURRENT_VERSION,
+} from '../src/common/versioning/versioning.middleware';
+
+const RATE_LIMIT_DESCRIPTION = `
+## Authentication
+
+All protected endpoints require a **Bearer JWT** in the \`Authorization\` header:
+
+\`\`\`
+Authorization: Bearer <token>
+\`\`\`
+
+Obtain a token via:
+- \`POST /api/v2/auth/register\` — email/password registration
+- \`POST /api/v2/auth/login\` — email/password login
+- \`POST /api/v2/auth/verify-signature\` — Stellar wallet login (Web3)
+
+---
+
+## Rate Limits
+
+| Tier       | Default (req/min) | Auth (req/15 min) | RPC (req/min) |
+|------------|:-----------------:|:-----------------:|:-------------:|
+| Free       | 60                | 5                 | 5             |
+| Verified   | 150               | 10                | 15            |
+| Premium    | 300               | 15                | 30            |
+| Enterprise | 1000              | 30                | 100           |
+| Admin      | 1000              | 50                | 100           |
+
+**Rate limit response headers:** \`X-RateLimit-Limit\`, \`X-RateLimit-Tier\`, \`X-RateLimit-Remaining\`, \`X-RateLimit-Reset\`, \`Retry-After\`
+
+---
+
+## Common Error Codes
+
+| HTTP | Meaning |
+|------|---------|
+| 400  | Validation failure |
+| 401  | Missing or invalid JWT |
+| 403  | Insufficient permissions |
+| 404  | Resource not found |
+| 409  | Conflict |
+| 429  | Rate limit exceeded |
+| 503  | Service temporarily unavailable |
+`;
 
 async function generate() {
   const app = await NestFactory.create(AppModule, { logger: false });
 
   app.setGlobalPrefix('api');
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
-
-  const config = new DocumentBuilder()
-    .setTitle('Nestera API')
-    .setDescription(
-      'Nestera is a decentralized savings & investment platform on Stellar. ' +
-      'All amounts are in USDC (7 decimal places).',
-    )
-    .setVersion('2')
-    .setContact('Nestera Team', 'https://github.com/Devsol-01/Nestera', 'support@nestera.io')
-    .setLicense('MIT', 'https://opensource.org/licenses/MIT')
-    .addServer('http://localhost:3001', 'Local development')
-    .addServer('https://api.nestera.io', 'Production')
-    .addBearerAuth(
-      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
-      'access-token',
-    )
-    .build();
-
-  const document = SwaggerModule.createDocument(app, config, {
-    extraModels: [PageDto, PageMetaDto, TransactionResponseDto],
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: CURRENT_VERSION,
   });
+
+  const versioningMiddleware = new VersioningMiddleware();
+  app.use(versioningMiddleware.use.bind(versioningMiddleware));
+
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
 
   const outDir = join(__dirname, '..');
 
-  // JSON
-  const jsonPath = join(outDir, 'openapi.json');
-  writeFileSync(jsonPath, JSON.stringify(document, null, 2), 'utf-8');
-  console.log(`✅  OpenAPI JSON written to ${jsonPath}`);
-
-  // YAML (built-in js-yaml is available via @nestjs/swagger)
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const yaml = require('js-yaml') as typeof import('js-yaml');
-  const yamlPath = join(outDir, 'openapi.yaml');
-  writeFileSync(yamlPath, yaml.dump(document, { lineWidth: 120 }), 'utf-8');
-  console.log(`✅  OpenAPI YAML written to ${yamlPath}`);
+
+  for (const version of ['1', '2']) {
+    const isDeprecated = version === '1';
+
+    const config = new DocumentBuilder()
+      .setTitle(`Nestera API v${version}`)
+      .setDescription(
+        isDeprecated
+          ? `> ⚠️ **DEPRECATED** — Sunset: 2026-09-01. Migrate to v2.\n\n${RATE_LIMIT_DESCRIPTION}`
+          : `Nestera decentralized savings & investment platform API.\n\n${RATE_LIMIT_DESCRIPTION}`,
+      )
+      .setVersion(version)
+      .setContact('Nestera', 'https://nestera.io', 'support@nestera.io')
+      .setLicense('MIT', 'https://opensource.org/licenses/MIT')
+      .addServer('http://localhost:3001', 'Local development')
+      .addServer('https://api.nestera.io', 'Production')
+      .addBearerAuth(
+        {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Enter your JWT token (without the "Bearer " prefix)',
+        },
+        'JWT',
+      )
+      .build();
+
+    const document = SwaggerModule.createDocument(app, config, {
+      extraModels: [PageDto, PageMetaDto, TransactionResponseDto],
+    });
+
+    const jsonPath = join(outDir, `openapi-v${version}.json`);
+    writeFileSync(jsonPath, JSON.stringify(document, null, 2), 'utf-8');
+    console.log(`✅  OpenAPI v${version} JSON  → ${jsonPath}`);
+
+    const yamlPath = join(outDir, `openapi-v${version}.yaml`);
+    writeFileSync(yamlPath, yaml.dump(document, { lineWidth: 120 }), 'utf-8');
+    console.log(`✅  OpenAPI v${version} YAML  → ${yamlPath}`);
+  }
+
+  // Backwards-compat aliases (openapi.json / openapi.yaml point to v2)
+  for (const ext of ['json', 'yaml']) {
+    const src = join(outDir, `openapi-v2.${ext}`);
+    const dest = join(outDir, `openapi.${ext}`);
+    // Read and re-write rather than symlink for cross-platform portability
+    const { readFileSync } = await import('fs');
+    writeFileSync(dest, readFileSync(src, 'utf-8'), 'utf-8');
+    console.log(`✅  openapi.${ext} alias       → ${dest}`);
+  }
 
   await app.close();
+  console.log('\nDone. Import openapi.json into Postman / Insomnia for interactive testing.');
 }
 
 generate().catch((err) => {

--- a/backend/src/common/dto/api-responses.dto.ts
+++ b/backend/src/common/dto/api-responses.dto.ts
@@ -1,0 +1,110 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/** Shape emitted by AllExceptionsFilter for HTTP error responses. */
+export class ErrorResponseDto {
+  @ApiProperty({ example: false })
+  success: boolean;
+
+  @ApiProperty({ example: 400 })
+  statusCode: number;
+
+  @ApiProperty({ example: '2026-06-01T12:00:00.000Z' })
+  timestamp: string;
+
+  @ApiProperty({ example: '/api/v2/savings/products' })
+  path: string;
+
+  @ApiProperty({ example: 'Validation failed' })
+  message: string;
+}
+
+export class UnauthorizedResponseDto extends ErrorResponseDto {
+  @ApiProperty({ example: 401 })
+  statusCode: number;
+
+  @ApiProperty({ example: 'Unauthorized' })
+  message: string;
+}
+
+export class ForbiddenResponseDto extends ErrorResponseDto {
+  @ApiProperty({ example: 403 })
+  statusCode: number;
+
+  @ApiProperty({ example: 'Forbidden resource' })
+  message: string;
+}
+
+export class NotFoundResponseDto extends ErrorResponseDto {
+  @ApiProperty({ example: 404 })
+  statusCode: number;
+
+  @ApiProperty({ example: 'Resource not found' })
+  message: string;
+}
+
+export class ConflictResponseDto extends ErrorResponseDto {
+  @ApiProperty({ example: 409 })
+  statusCode: number;
+
+  @ApiProperty({ example: 'Resource already exists' })
+  message: string;
+}
+
+export class TooManyRequestsResponseDto {
+  @ApiProperty({ example: false })
+  success: boolean;
+
+  @ApiProperty({ example: 429 })
+  statusCode: number;
+
+  @ApiProperty({ example: 'Rate limit exceeded for free tier. Maximum 60 requests per 60 seconds.' })
+  message: string;
+
+  @ApiProperty({
+    description: 'Seconds to wait before retrying (also returned in Retry-After header)',
+    example: 60,
+  })
+  retryAfter: number;
+}
+
+export class ValidationErrorResponseDto extends ErrorResponseDto {
+  @ApiProperty({ example: 422 })
+  statusCode: number;
+
+  @ApiProperty({
+    example: 'targetAmount must be a positive number; goalName should not be empty',
+  })
+  message: string;
+}
+
+/** Generic paginated wrapper. */
+export class PaginatedMetaDto {
+  @ApiProperty({ example: 1 })
+  page: number;
+
+  @ApiProperty({ example: 20 })
+  take: number;
+
+  @ApiProperty({ example: 150 })
+  itemCount: number;
+
+  @ApiProperty({ example: 8 })
+  pageCount: number;
+
+  @ApiProperty({ example: false })
+  hasPreviousPage: boolean;
+
+  @ApiProperty({ example: true })
+  hasNextPage: boolean;
+}
+
+export class SuccessMessageDto {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Operation completed successfully' })
+  message: string;
+
+  @ApiPropertyOptional()
+  data?: unknown;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -42,29 +42,118 @@ async function bootstrap() {
     }),
   );
 
-  // Swagger setup — one document per supported version
+  // ── Swagger / OpenAPI setup ───────────────────────────────────────────────
+  const rateLimitDescription = `
+## Authentication
+
+All protected endpoints require a **Bearer JWT** in the \`Authorization\` header:
+
+\`\`\`
+Authorization: Bearer <token>
+\`\`\`
+
+Obtain a token via:
+- \`POST /api/v2/auth/register\` — email/password registration
+- \`POST /api/v2/auth/login\` — email/password login
+- \`POST /api/v2/auth/verify-signature\` — Stellar wallet login (Web3)
+
+If 2FA is enabled, complete login via \`POST /api/v2/auth/2fa/validate\`.
+
+---
+
+## Rate Limits
+
+Rate limits are enforced per **user tier** and returned in response headers:
+
+| Tier       | Default (req/min) | Auth (req/15 min) | RPC (req/min) |
+|------------|:-----------------:|:-----------------:|:-------------:|
+| Free       | 60                | 5                 | 5             |
+| Verified   | 150               | 10                | 15            |
+| Premium    | 300               | 15                | 30            |
+| Enterprise | 1000              | 30                | 100           |
+| Admin      | 1000              | 50                | 100           |
+
+**Headers returned on every response:**
+- \`X-RateLimit-Limit\` — current limit for the active throttler
+- \`X-RateLimit-Tier\` — resolved tier for the request
+- \`X-RateLimit-Remaining\` — requests remaining (set on 429)
+- \`X-RateLimit-Reset\` — ISO timestamp when the window resets (set on 429)
+- \`Retry-After\` — seconds to wait before retrying (set on 429)
+
+---
+
+## Versioning
+
+The API supports URI-based versioning (\`/api/v1/...\` and \`/api/v2/...\`).
+
+> ⚠️ **v1 is deprecated** and will be sunset on **2026-09-01**. Migrate to v2.
+
+---
+
+## Common Error Codes
+
+| HTTP Status | Meaning                          |
+|-------------|----------------------------------|
+| 400         | Bad request / validation failure |
+| 401         | Missing or invalid JWT           |
+| 403         | Insufficient permissions (RBAC)  |
+| 404         | Resource not found               |
+| 409         | Conflict (e.g. duplicate wallet) |
+| 429         | Rate limit exceeded              |
+| 503         | Service temporarily unavailable  |
+`;
+
   for (const version of ['1', '2']) {
+    const isDeprecated = version === '1';
     const swaggerConfig = new DocumentBuilder()
       .setTitle(`Nestera API v${version}`)
       .setDescription(
-        version === '1'
-          ? 'API v1 — DEPRECATED. Sunset: 2026-09-01. Migrate to v2.'
-          : 'API v2 — Current stable version.',
+        isDeprecated
+          ? `> ⚠️ **DEPRECATED** — Sunset: 2026-09-01. Migrate to v2.\n\n${rateLimitDescription}`
+          : `Nestera decentralized savings & investment platform API.\n\n${rateLimitDescription}`,
       )
       .setVersion(version)
-      .addBearerAuth()
+      .setContact('Nestera', 'https://nestera.io', 'support@nestera.io')
+      .setLicense('MIT', 'https://opensource.org/licenses/MIT')
+      .addBearerAuth(
+        {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Enter your JWT token (without the "Bearer " prefix)',
+        },
+        'JWT',
+      )
+      .addServer(`http://localhost:${port || 3001}`, 'Local development')
       .build();
     const document = SwaggerModule.createDocument(app, swaggerConfig);
-    SwaggerModule.setup(`api/v${version}/docs`, app, document);
+    SwaggerModule.setup(`api/v${version}/docs`, app, document, {
+      swaggerOptions: {
+        persistAuthorization: true,
+        tagsSorter: 'alpha',
+        operationsSorter: 'alpha',
+        docExpansion: 'none',
+        filter: true,
+        showRequestDuration: true,
+      },
+      customSiteTitle: `Nestera API v${version} Docs`,
+    });
   }
+
+  // Redirect /api/docs → /api/v2/docs for convenience
+  const expressApp = app.getHttpAdapter().getInstance();
+  expressApp.get('/api/docs', (_req: unknown, res: { redirect: (url: string) => void }) => {
+    res.redirect('/api/v2/docs');
+  });
 
   const server = await app.listen(port || 3001);
   const logger = app.get(Logger);
   logger.log(`Application is running on: http://localhost:${port}/api`);
+  logger.log(`Swagger docs (current):    http://localhost:${port}/api/docs`);
+  logger.log(`Swagger v2 docs:           http://localhost:${port}/api/v2/docs`);
   logger.log(
     `Swagger v1 docs (deprecated): http://localhost:${port}/api/v1/docs`,
   );
-  logger.log(`Swagger v2 docs: http://localhost:${port}/api/v2/docs`);
 
   // Setup graceful shutdown
   const gracefulShutdown = app.get(GracefulShutdownService);

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -12,6 +12,8 @@ import {
   ApiTags,
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
+  ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
 import { UserService } from '../user/user.service';
@@ -34,6 +36,13 @@ export class AdminController {
   ) {}
 
   @Patch('users/:id/kyc/approve')
+  @ApiOperation({ summary: 'Approve KYC for a user' })
+  @ApiParam({ name: 'id', description: 'User UUID' })
+  @ApiResponse({ status: 200, description: 'KYC approved' })
+  @ApiResponse({ status: 400, description: 'Missing user ID' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async approveKyc(@Param('id') userId: string) {
     if (!userId) {
       throw new BadRequestException('User ID is required');
@@ -42,6 +51,13 @@ export class AdminController {
   }
 
   @Patch('users/:id/kyc/reject')
+  @ApiOperation({ summary: 'Reject KYC for a user' })
+  @ApiParam({ name: 'id', description: 'User UUID' })
+  @ApiResponse({ status: 200, description: 'KYC rejected' })
+  @ApiResponse({ status: 400, description: 'Missing user ID or rejection reason' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async rejectKyc(@Param('id') userId: string, @Body() dto: RejectKycDto) {
     if (!userId) {
       throw new BadRequestException('User ID is required');
@@ -53,6 +69,16 @@ export class AdminController {
   }
 
   @Patch('users/:id/kyc')
+  @ApiOperation({
+    summary: 'Approve or reject KYC for a user (single endpoint)',
+    description: 'Set `action` to `"approve"` or `"reject"`. Reason is required for rejection.',
+  })
+  @ApiParam({ name: 'id', description: 'User UUID' })
+  @ApiResponse({ status: 200, description: 'KYC status updated' })
+  @ApiResponse({ status: 400, description: 'Invalid action or missing reason' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async updateKycStatus(
     @Param('id') userId: string,
     @Body() body: { action: 'approve' | 'reject'; reason?: string },
@@ -78,13 +104,18 @@ export class AdminController {
   @Get('rate-limits/summary')
   @ApiOperation({ summary: 'Get rate limit violation summary' })
   @ApiResponse({ status: 200, description: 'Rate limit violation summary' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
   getRateLimitSummary() {
     return this.rateLimitMonitor.getViolationSummary();
   }
 
   @Get('rate-limits/violations')
   @ApiOperation({ summary: 'Get recent rate limit violations' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Max results (default 50)', type: Number })
   @ApiResponse({ status: 200, description: 'Recent rate limit violations' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
   getRecentViolations(@Query('limit') limit?: string) {
     return this.rateLimitMonitor.getRecentViolations(
       limit ? parseInt(limit, 10) : 50,
@@ -93,7 +124,11 @@ export class AdminController {
 
   @Get('rate-limits/violations/:userId')
   @ApiOperation({ summary: 'Get rate limit violations for a specific user' })
+  @ApiParam({ name: 'userId', description: 'User UUID' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Max results (default 50)', type: Number })
   @ApiResponse({ status: 200, description: 'User rate limit violations' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
   getUserViolations(
     @Param('userId') userId: string,
     @Query('limit') limit?: string,

--- a/backend/src/modules/savings/dto/product-details.dto.ts
+++ b/backend/src/modules/savings/dto/product-details.dto.ts
@@ -8,74 +8,69 @@ import {
  * Detailed product response combining static DB attributes with live Soroban contract data
  */
 export class ProductDetailsDto {
-  @ApiProperty({ description: 'Product UUID' })
+  @ApiProperty({ example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479', description: 'Product UUID' })
   id: string;
 
-  @ApiProperty({ description: 'Product name' })
+  @ApiProperty({ example: 'Flexible Saver', description: 'Product name' })
   name: string;
 
-  @ApiProperty({ enum: SavingsProductType, description: 'Product type' })
+  @ApiProperty({ enum: SavingsProductType, example: SavingsProductType.FLEXIBLE, description: 'Product type' })
   type: SavingsProductType;
 
-  @ApiPropertyOptional({ description: 'Product description' })
+  @ApiPropertyOptional({ example: 'Earn 6% APY with no lock-up period.', description: 'Product description' })
   description: string | null;
 
-  @ApiProperty({ description: 'Annual interest rate (%)' })
+  @ApiProperty({ example: 6.0, description: 'Annual interest rate (%)' })
   interestRate: number;
 
-  @ApiProperty({ description: 'Minimum subscription amount' })
+  @ApiProperty({ example: 10, description: 'Minimum subscription amount (XLM)' })
   minAmount: number;
 
-  @ApiProperty({ description: 'Maximum subscription amount' })
+  @ApiProperty({ example: 100000, description: 'Maximum subscription amount (XLM)' })
   maxAmount: number;
 
-  @ApiPropertyOptional({ description: 'Tenure in months' })
+  @ApiPropertyOptional({ example: null, description: 'Tenure in months (null for flexible)' })
   tenureMonths: number | null;
 
-  @ApiProperty({ description: 'Whether product is active' })
+  @ApiProperty({ example: true, description: 'Whether product is active' })
   isActive: boolean;
 
-  @ApiPropertyOptional({
-    description: 'Maximum active subscriptions allowed per user',
-  })
+  @ApiPropertyOptional({ example: 3, description: 'Maximum active subscriptions allowed per user' })
   maxSubscriptionsPerUser: number | null;
-  @ApiProperty({ description: 'Current product version' })
+
+  @ApiProperty({ example: 1, description: 'Current product version' })
   version: number;
 
-  @ApiPropertyOptional({ description: 'Soroban vault contract ID' })
+  @ApiPropertyOptional({ example: 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA', description: 'Soroban vault contract ID' })
   contractId: string | null;
 
-  @ApiProperty({
-    description: 'Live total assets from Soroban contract (in stroops)',
-  })
+  @ApiProperty({ example: 12500000000, description: 'Live total assets from Soroban contract (in stroops)' })
   totalAssets: number;
 
-  @ApiProperty({ description: 'Live total assets formatted as XLM' })
+  @ApiProperty({ example: 1250.0, description: 'Live total assets formatted as XLM' })
   totalAssetsXlm: number;
 
-  @ApiPropertyOptional({
-    description: 'Maximum liquidity-backed capacity for the product',
-  })
+  @ApiPropertyOptional({ example: 5000000, description: 'Maximum liquidity-backed capacity for the product' })
   maxCapacity: number | null;
 
-  @ApiProperty({ description: 'Current utilized capacity amount' })
+  @ApiProperty({ example: 1250000, description: 'Current utilized capacity amount' })
   utilizedCapacity: number;
 
-  @ApiProperty({ description: 'Remaining capacity amount' })
+  @ApiProperty({ example: 3750000, description: 'Remaining capacity amount' })
   availableCapacity: number;
 
-  @ApiProperty({ description: 'Capacity utilization percentage' })
+  @ApiProperty({ example: 25.0, description: 'Capacity utilization percentage' })
   utilizationPercentage: number;
 
-  @ApiProperty({ description: 'Whether the product is fully utilized' })
+  @ApiProperty({ example: false, description: 'Whether the product is fully utilized' })
   isFull: boolean;
 
-  @ApiProperty({ description: 'Product creation timestamp' })
+  @ApiProperty({ example: '2025-01-15T10:00:00.000Z', description: 'Product creation timestamp' })
   createdAt: Date;
 
-  @ApiProperty({ description: 'Risk level classification', enum: RiskLevel })
+  @ApiProperty({ example: RiskLevel.LOW, description: 'Risk level classification', enum: RiskLevel })
   riskLevel: RiskLevel;
 
-  @ApiProperty({ description: 'Product last update timestamp' })
+  @ApiProperty({ example: '2026-03-20T14:30:00.000Z', description: 'Product last update timestamp' })
   updatedAt: Date;
 }

--- a/backend/src/modules/savings/dto/savings-product.dto.ts
+++ b/backend/src/modules/savings/dto/savings-product.dto.ts
@@ -5,69 +5,63 @@ import {
 } from '../entities/savings-product.entity';
 
 export class SavingsProductDto {
-  @ApiProperty({ description: 'Product UUID' })
+  @ApiProperty({ example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479', description: 'Product UUID' })
   id: string;
 
-  @ApiProperty({ description: 'Product name' })
+  @ApiProperty({ example: 'Flexible Saver', description: 'Product name' })
   name: string;
 
-  @ApiProperty({ enum: SavingsProductType, description: 'Product type' })
+  @ApiProperty({ enum: SavingsProductType, example: SavingsProductType.FLEXIBLE, description: 'Product type' })
   type: SavingsProductType;
 
-  @ApiPropertyOptional({ description: 'Product description' })
+  @ApiPropertyOptional({ example: 'Earn 6% APY with no lock-up period.', description: 'Product description' })
   description: string | null;
 
-  @ApiProperty({ description: 'Annual interest rate (%)' })
+  @ApiProperty({ example: 6.0, description: 'Annual interest rate (%)' })
   interestRate: number;
 
-  @ApiProperty({ description: 'Minimum subscription amount' })
+  @ApiProperty({ example: 10, description: 'Minimum subscription amount (XLM)' })
   minAmount: number;
 
-  @ApiProperty({ description: 'Maximum subscription amount' })
+  @ApiProperty({ example: 100000, description: 'Maximum subscription amount (XLM)' })
   maxAmount: number;
 
-  @ApiPropertyOptional({ description: 'Tenure in months' })
+  @ApiPropertyOptional({ example: 12, description: 'Tenure in months (null for flexible)' })
   tenureMonths: number | null;
 
-  @ApiPropertyOptional({ description: 'Soroban vault contract ID' })
+  @ApiPropertyOptional({ example: 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA', description: 'Soroban vault contract ID' })
   contractId: string | null;
 
-  @ApiProperty({ description: 'Whether product is active' })
+  @ApiProperty({ example: true, description: 'Whether product is active' })
   isActive: boolean;
 
-  @ApiPropertyOptional({
-    description: 'Maximum active subscriptions allowed per user',
-  })
+  @ApiPropertyOptional({ example: 3, description: 'Maximum active subscriptions allowed per user' })
   maxSubscriptionsPerUser: number | null;
-  @ApiProperty({ description: 'Current product version' })
+
+  @ApiProperty({ example: 1, description: 'Current product version' })
   version: number;
 
-  @ApiProperty({
-    description: 'Risk level classification (e.g. Low, Medium, High)',
-    enum: RiskLevel,
-  })
+  @ApiProperty({ example: RiskLevel.LOW, description: 'Risk level classification', enum: RiskLevel })
   riskLevel: RiskLevel;
 
-  @ApiProperty({ description: 'Total Value Locked (aggregated local balance)' })
+  @ApiProperty({ example: 1250000, description: 'Total Value Locked (aggregated local balance)' })
   tvlAmount: number;
 
-  @ApiPropertyOptional({
-    description: 'Maximum liquidity-backed capacity for the product',
-  })
+  @ApiPropertyOptional({ example: 5000000, description: 'Maximum liquidity-backed capacity for the product' })
   maxCapacity: number | null;
 
-  @ApiProperty({ description: 'Current utilized capacity amount' })
+  @ApiProperty({ example: 1250000, description: 'Current utilized capacity amount' })
   utilizedCapacity: number;
 
-  @ApiProperty({ description: 'Remaining capacity amount' })
+  @ApiProperty({ example: 3750000, description: 'Remaining capacity amount' })
   availableCapacity: number;
 
-  @ApiProperty({ description: 'Capacity utilization percentage' })
+  @ApiProperty({ example: 25.0, description: 'Capacity utilization percentage' })
   utilizationPercentage: number;
 
-  @ApiProperty({ description: 'Product creation timestamp' })
+  @ApiProperty({ example: '2025-01-15T10:00:00.000Z', description: 'Product creation timestamp' })
   createdAt: Date;
 
-  @ApiProperty({ description: 'Product last update timestamp' })
+  @ApiProperty({ example: '2026-03-20T14:30:00.000Z', description: 'Product last update timestamp' })
   updatedAt: Date;
 }

--- a/backend/src/modules/savings/dto/subscribe.dto.ts
+++ b/backend/src/modules/savings/dto/subscribe.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsStellarPublicKey } from '../../../common/validators/is-stellar-key.validator';
 
 export class SubscribeDto {
-  @ApiProperty({ description: 'Savings product ID to subscribe to' })
+  @ApiProperty({ example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479', description: 'Savings product ID to subscribe to' })
   @IsUUID()
   productId: string;
 

--- a/backend/src/modules/savings/dto/withdraw.dto.ts
+++ b/backend/src/modules/savings/dto/withdraw.dto.ts
@@ -2,7 +2,7 @@ import { IsUUID, IsNumber, Min, IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class WithdrawDto {
-  @ApiProperty({ description: 'Subscription ID to withdraw from' })
+  @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', description: 'Subscription ID to withdraw from' })
   @IsUUID()
   subscriptionId: string;
 

--- a/backend/src/modules/transactions/transactions.controller.ts
+++ b/backend/src/modules/transactions/transactions.controller.ts
@@ -11,7 +11,9 @@ import {
 import { Response } from 'express';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -85,6 +87,12 @@ export class TransactionsController {
   }
 
   @Post(':id/tag')
+  @ApiOperation({ summary: 'Tag a transaction with a label or category' })
+  @ApiParam({ name: 'id', description: 'Transaction UUID' })
+  @ApiBody({ type: TagTransactionDto })
+  @ApiResponse({ status: 201, description: 'Transaction tagged' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Transaction not found' })
   async tagTransaction(
     @CurrentUser() user: { id: string },
     @Param('id') id: string,
@@ -94,11 +102,21 @@ export class TransactionsController {
   }
 
   @Get('categories')
+  @ApiOperation({ summary: 'List all transaction categories used by the authenticated user' })
+  @ApiResponse({ status: 200, description: 'List of category strings' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getCategories(@CurrentUser() user: { id: string }) {
     return this.transactionsService.listCategories(user.id);
   }
 
   @Post('tags/bulk')
+  @ApiOperation({
+    summary: 'Bulk tag multiple transactions at once',
+    description: 'Apply tags/categories to a list of transaction IDs in a single request.',
+  })
+  @ApiBody({ type: BulkTagDto })
+  @ApiResponse({ status: 201, description: 'Transactions tagged' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async bulkTag(@CurrentUser() user: { id: string }, @Body() body: BulkTagDto) {
     return this.transactionsService.bulkTag(user.id, body);
   }

--- a/backend/src/modules/user/user.controller.ts
+++ b/backend/src/modules/user/user.controller.ts
@@ -18,7 +18,10 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -112,11 +115,21 @@ export class UserController {
 
   @Get('me')
   @ApiOperation({ summary: 'Get basic info for the authenticated user' })
+  @ApiResponse({ status: 200, description: 'User info returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getMe(@CurrentUser() user: { id: string }) {
     return this.userService.findById(user.id);
   }
 
   @Get('me/net-worth')
+  @ApiOperation({
+    summary: 'Get net worth breakdown for the authenticated user',
+    description:
+      'Returns wallet balance, savings (flexible + locked), total, and percentage breakdown. ' +
+      'Requires a linked Stellar wallet; returns zero balances if no wallet is linked.',
+  })
+  @ApiResponse({ status: 200, description: 'Net worth data', type: NetWorthDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getNetWorth(@CurrentUser() user: { id: string }): Promise<NetWorthDto> {
     const userEntity = await this.userService.findById(user.id);
 
@@ -162,21 +175,48 @@ export class UserController {
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a user by ID (admin / internal use)' })
+  @ApiParam({ name: 'id', description: 'User UUID' })
+  @ApiResponse({ status: 200, description: 'User record' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   findOne(@Param('id') id: string) {
     return this.userService.findById(id);
   }
 
   @Patch('me')
+  @ApiOperation({ summary: 'Update the authenticated user profile' })
+  @ApiBody({ type: UpdateUserDto })
+  @ApiResponse({ status: 200, description: 'Profile updated' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   updateMe(@CurrentUser() user: { id: string }, @Body() dto: UpdateUserDto) {
     return this.userService.update(user.id, dto);
   }
 
   @Delete('me')
+  @ApiOperation({ summary: 'Delete the authenticated user account' })
+  @ApiResponse({ status: 200, description: 'Account deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   deleteMe(@CurrentUser() user: { id: string }) {
     return this.userService.remove(user.id);
   }
 
   @Post('avatar')
+  @ApiOperation({
+    summary: 'Upload a profile avatar image',
+    description: 'Accepts JPEG, PNG, or WebP up to 5 MB.',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Avatar uploaded, URL returned' })
+  @ApiResponse({ status: 400, description: 'Invalid file type or size' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseInterceptors(FileInterceptor('file'))
   async uploadAvatar(
     @CurrentUser() user: { id: string },
@@ -195,6 +235,20 @@ export class UserController {
   }
 
   @Post('me/kyc-docs')
+  @ApiOperation({
+    summary: 'Upload a KYC document',
+    description: 'Accepts PDF or JPEG up to 10 MB. Triggers KYC review process.',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { document: { type: 'string', format: 'binary' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'KYC document uploaded' })
+  @ApiResponse({ status: 400, description: 'Invalid file type or size' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseInterceptors(FileInterceptor('document'))
   async uploadKycDocument(
     @CurrentUser() user: { id: string },


### PR DESCRIPTION
feat: Comprehensive Swagger/OpenAPI Documentation
  
  Summary
  
  Adds interactive API documentation hosted at /api/docs, with full request/response examples,
  authentication guides, and rate limiting information.
  
  What's Changed
  
  Interactive Docs
  
  - /api/docs → redirects to /api/v2/docs (canonical entry point)
  - /api/v2/docs — current stable API
  - /api/v1/docs — deprecated API (sunset 2026-09-01)
  - Swagger UI configured with persistAuthorization, search filter, tag sorting, and request
  duration display
  
  Documentation Content
  
  - Authentication guide (email/password + Web3 wallet login flows)
  - Rate limit table per user tier (Free → Admin) with response header reference
  - URI versioning explanation with v1 deprecation notice
  - Common HTTP error code reference
  
  Code Changes
  
  - src/common/dto/api-responses.dto.ts — new shared response DTOs (ErrorResponseDto,
  UnauthorizedResponseDto, ForbiddenResponseDto, NotFoundResponseDto, ConflictResponseDto,
  TooManyRequestsResponseDto, ValidationErrorResponseDto)
  - admin.controller.ts — added @ApiOperation, @ApiParam, @ApiQuery, @ApiResponse to all KYC and
  rate-limit endpoints
  - user.controller.ts — added decorators to getMe, getNetWorth, findOne, updateMe, deleteMe,
  uploadAvatar, uploadKycDocument (including @ApiConsumes for file uploads)
  - transactions.controller.ts — added decorators to tagTransaction, getCategories, bulkTag
  - Savings DTOs (SavingsProductDto, ProductDetailsDto, SubscribeDto, WithdrawDto) — added
  concrete example values to all @ApiProperty fields
  - scripts/generate-openapi-spec.ts — updated to generate openapi-v1.json/yaml,
  openapi-v2.json/yaml, and openapi.json/yaml (v2 alias)
  - package.json — added generate:openapi script
  
  Testing
  
  Run the backend and visit http://localhost:3001/api/docs to verify the interactive docs load
  correctly. Use the Authorize button to enter a JWT and test protected endpoints directly from
  the UI.
closes #902