### PR TITLE
Implement graceful shutdown handling

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -49,6 +49,7 @@ import { PostmanModule } from './common/postman/postman.module';
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
 import { JobsModule } from './modules/jobs/jobs.module';
 import { GracefulShutdownService } from './common/services/graceful-shutdown.service';
+import { PerformanceModule } from './modules/performance/performance.module';
 
 const envValidationSchema = Joi.object({
   NODE_ENV: Joi.string().valid('development', 'production', 'test').required(),
@@ -99,31 +100,7 @@ const envValidationSchema = Joi.object({
 
 @Module({
   imports: [
-    LoggerModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        const isProduction =
-          configService.get<string>('NODE_ENV') === 'production';
-        return {
-          pinoHttp: {
-            transport: isProduction
-              ? undefined
-              : { target: 'pino-pretty', options: { singleLine: true } },
-            level: isProduction ? 'info' : 'debug',
-          },
-        };
-      },
-    }),
-    BullModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (config: ConfigService) => ({
-        redis: {
-          uri: config.get<string>('REDIS_URL') || 'redis://localhost:6379',
-        },
-      }),
-    }),
+    ConfigModule.forRoot({
       isGlobal: true,
       load: [configuration],
       validationSchema: envValidationSchema,
@@ -149,6 +126,31 @@ const envValidationSchema = Joi.object({
 
         return value;
       },
+    }),
+    LoggerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => {
+        const isProduction =
+          configService.get<string>('NODE_ENV') === 'production';
+        return {
+          pinoHttp: {
+            transport: isProduction
+              ? undefined
+              : { target: 'pino-pretty', options: { singleLine: true } },
+            level: isProduction ? 'info' : 'debug',
+          },
+        };
+      },
+    }),
+    BullModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        redis: {
+          uri: config.get<string>('REDIS_URL') || 'redis://localhost:6379',
+        },
+      }),
     }),
     EventEmitterModule.forRoot(),
     ScheduleModule.forRoot(),
@@ -187,7 +189,6 @@ const envValidationSchema = Joi.object({
         };
       },
     }),
-    ScheduleModule.forRoot(),
     AuthModule,
     CacheModule,
     HealthModule,
@@ -218,6 +219,7 @@ const envValidationSchema = Joi.object({
     CircuitBreakerModule,
     PostmanModule,
     PerformanceModule,
+    JobsModule,
     CommonModule,
     ThrottlerModule.forRoot([
       {
@@ -263,7 +265,7 @@ const envValidationSchema = Joi.object({
     },
   ],
 })
-export class AppModule {
+export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(CorrelationIdMiddleware).forRoutes('*');
   }

--- a/backend/src/common/database/connection-pool.config.ts
+++ b/backend/src/common/database/connection-pool.config.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 
@@ -12,10 +12,11 @@ export interface PoolMetrics {
 }
 
 @Injectable()
-export class ConnectionPoolService {
+export class ConnectionPoolService implements OnModuleDestroy {
   private readonly logger = new Logger(ConnectionPoolService.name);
   private metrics: PoolMetrics[] = [];
   private readonly maxMetricsHistory = 1000;
+  private monitorInterval: NodeJS.Timeout | null = null;
 
   constructor(
     private configService: ConfigService,
@@ -25,9 +26,16 @@ export class ConnectionPoolService {
   }
 
   private initializePoolMonitoring() {
-    setInterval(() => {
+    this.monitorInterval = setInterval(() => {
       this.collectMetrics();
     }, 30000); // Collect every 30 seconds
+  }
+
+  onModuleDestroy(): void {
+    if (this.monitorInterval) {
+      clearInterval(this.monitorInterval);
+      this.monitorInterval = null;
+    }
   }
 
   private collectMetrics() {

--- a/backend/src/common/decorators/shutdown-task.decorator.ts
+++ b/backend/src/common/decorators/shutdown-task.decorator.ts
@@ -1,0 +1,22 @@
+import { GracefulShutdownService } from '../services/graceful-shutdown.service';
+
+export function ShutdownTrackedTask(taskName?: string): MethodDecorator {
+  return (target, propertyKey, descriptor) => {
+    const originalMethod = descriptor.value;
+
+    if (typeof originalMethod !== 'function') {
+      return descriptor;
+    }
+
+    descriptor.value = async function (...args: unknown[]) {
+      const resolvedTaskName =
+        taskName ?? `${target.constructor.name}.${String(propertyKey)}`;
+
+      return GracefulShutdownService.runTrackedTask(resolvedTaskName, () =>
+        Promise.resolve(originalMethod.apply(this, args)),
+      );
+    };
+
+    return descriptor;
+  };
+}

--- a/backend/src/common/interceptors/graceful-shutdown.interceptor.spec.ts
+++ b/backend/src/common/interceptors/graceful-shutdown.interceptor.spec.ts
@@ -1,0 +1,62 @@
+import { EMPTY, of } from 'rxjs';
+import { GracefulShutdownInterceptor } from './graceful-shutdown.interceptor';
+import { GracefulShutdownService } from '../services/graceful-shutdown.service';
+
+describe('GracefulShutdownInterceptor', () => {
+  const createContext = () => {
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    return {
+      response,
+      context: {
+        switchToHttp: () => ({
+          getResponse: () => response,
+        }),
+      },
+    };
+  };
+
+  it('rejects new requests while shutdown is in progress', () => {
+    const gracefulShutdown = {
+      isShutdown: jest.fn().mockReturnValue(true),
+      incrementActiveRequests: jest.fn(),
+      decrementActiveRequests: jest.fn(),
+    } as unknown as GracefulShutdownService;
+    const interceptor = new GracefulShutdownInterceptor(gracefulShutdown);
+    const { context, response } = createContext();
+
+    const result = interceptor.intercept(context as never, {
+      handle: () => of('ok'),
+    } as never);
+
+    expect(result).toBe(EMPTY);
+    expect(response.status).toHaveBeenCalledWith(503);
+    expect(gracefulShutdown.incrementActiveRequests).not.toHaveBeenCalled();
+  });
+
+  it('tracks accepted requests until completion', (done) => {
+    const gracefulShutdown = {
+      isShutdown: jest.fn().mockReturnValue(false),
+      incrementActiveRequests: jest.fn(),
+      decrementActiveRequests: jest.fn(),
+    } as unknown as GracefulShutdownService;
+    const interceptor = new GracefulShutdownInterceptor(gracefulShutdown);
+    const { context } = createContext();
+
+    interceptor
+      .intercept(context as never, {
+        handle: () => of('ok'),
+      } as never)
+      .subscribe({
+        complete: () => {
+          expect(gracefulShutdown.incrementActiveRequests).toHaveBeenCalled();
+          expect(gracefulShutdown.decrementActiveRequests).toHaveBeenCalled();
+          done();
+        },
+      });
+  });
+});

--- a/backend/src/common/interceptors/graceful-shutdown.interceptor.ts
+++ b/backend/src/common/interceptors/graceful-shutdown.interceptor.ts
@@ -16,6 +16,7 @@ export class GracefulShutdownInterceptor implements NestInterceptor {
     // Reject new requests during shutdown
     if (this.gracefulShutdown.isShutdown()) {
       const response = context.switchToHttp().getResponse();
+      response.setHeader?.('Connection', 'close');
       response.status(503).json({
         statusCode: 503,
         message: 'Service is shutting down',

--- a/backend/src/common/services/graceful-shutdown.service.spec.ts
+++ b/backend/src/common/services/graceful-shutdown.service.spec.ts
@@ -1,0 +1,87 @@
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { GracefulShutdownService } from './graceful-shutdown.service';
+
+describe('GracefulShutdownService', () => {
+  const createService = () => {
+    jest.useFakeTimers();
+
+    const dataSource = {
+      isInitialized: true,
+      destroy: jest.fn().mockResolvedValue(undefined),
+    } as const;
+
+    const schedulerRegistry = {
+      getCronJobs: jest.fn().mockReturnValue(
+        new Map([
+          ['heartbeat', { stop: jest.fn() }],
+        ]),
+      ),
+      getIntervals: jest.fn().mockReturnValue(['metrics']),
+      getInterval: jest.fn().mockReturnValue(setInterval(() => undefined, 1_000)),
+      deleteInterval: jest.fn(),
+      getTimeouts: jest.fn().mockReturnValue(['reconnect']),
+      getTimeout: jest.fn().mockReturnValue(setTimeout(() => undefined, 1_000)),
+      deleteTimeout: jest.fn(),
+    } as unknown as SchedulerRegistry;
+
+    const service = new GracefulShutdownService(
+      dataSource as never,
+      undefined,
+      schedulerRegistry,
+    );
+
+    return { dataSource, schedulerRegistry, service };
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('tracks background tasks while they are running', async () => {
+    const { service } = createService();
+
+    let releaseTask!: () => void;
+    const runningTask = GracefulShutdownService.runTrackedTask(
+      'spec.task',
+      () =>
+        new Promise<void>((resolve) => {
+          releaseTask = resolve;
+        }),
+    );
+
+    expect(service.getActiveBackgroundTaskCount()).toBe(1);
+
+    releaseTask();
+    await runningTask;
+
+    expect(service.getActiveBackgroundTaskCount()).toBe(0);
+  });
+
+  it('skips new background tasks after shutdown starts', async () => {
+    const { service } = createService();
+    const task = jest.fn();
+
+    service.beginShutdown('SIGTERM');
+    await GracefulShutdownService.runTrackedTask('spec.task', task);
+
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  it('stops schedulers and closes the database during shutdown', async () => {
+    const { dataSource, schedulerRegistry, service } = createService();
+
+    await service.beforeApplicationShutdown('SIGTERM');
+
+    const cronJobs = schedulerRegistry.getCronJobs() as Map<
+      string,
+      { stop: jest.Mock }
+    >;
+    const heartbeatJob = cronJobs.get('heartbeat');
+
+    expect(heartbeatJob?.stop).toHaveBeenCalled();
+    expect(schedulerRegistry.deleteInterval).toHaveBeenCalledWith('metrics');
+    expect(schedulerRegistry.deleteTimeout).toHaveBeenCalledWith('reconnect');
+    expect(dataSource.destroy).toHaveBeenCalled();
+  });
+});

--- a/backend/src/common/services/graceful-shutdown.service.ts
+++ b/backend/src/common/services/graceful-shutdown.service.ts
@@ -1,101 +1,336 @@
-import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
-import { DataSource } from 'typeorm';
+import {
+  BeforeApplicationShutdown,
+  Inject,
+  Injectable,
+  Logger,
+  Optional,
+} from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import { Cache } from 'cache-manager';
+import type { Server } from 'node:http';
+import type { Socket } from 'node:net';
+import { DataSource } from 'typeorm';
+
+type ShutdownManagedServer = Server & {
+  closeIdleConnections?: () => void;
+  closeAllConnections?: () => void;
+};
 
 @Injectable()
-export class GracefulShutdownService implements OnApplicationShutdown {
+export class GracefulShutdownService implements BeforeApplicationShutdown {
+  private static instance: GracefulShutdownService | null = null;
+
   private readonly logger = new Logger(GracefulShutdownService.name);
+  private readonly activeSockets = new Set<Socket>();
+  private readonly shutdownTimeoutMs = 30_000;
+  private readonly drainPollIntervalMs = 250;
+
   private isShuttingDown = false;
+  private schedulersStopped = false;
   private activeRequests = 0;
-  private readonly maxShutdownTimeout = 30000; // 30 seconds
+  private activeBackgroundTasks = 0;
+  private registeredHttpServer?: ShutdownManagedServer;
+  private closeServerPromise: Promise<void> | null = null;
+  private shutdownPromise: Promise<number> | null = null;
 
   constructor(
-    private dataSource: DataSource,
-    @Inject(CACHE_MANAGER) private cacheManager: Cache,
-  ) {}
-
-  incrementActiveRequests(): void {
-    if (!this.isShuttingDown) {
-      this.activeRequests++;
-    }
+    private readonly dataSource: DataSource,
+    @Optional()
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager?: Cache,
+    @Optional()
+    private readonly schedulerRegistry?: SchedulerRegistry,
+  ) {
+    GracefulShutdownService.instance = this;
   }
 
-  decrementActiveRequests(): void {
-    this.activeRequests--;
+  static async runTrackedTask<T>(
+    taskName: string,
+    task: () => Promise<T> | T,
+  ): Promise<T | undefined> {
+    if (!GracefulShutdownService.instance) {
+      return Promise.resolve(task());
+    }
+
+    return GracefulShutdownService.instance.runBackgroundTask(taskName, task);
+  }
+
+  registerHttpServer(server: Server): void {
+    if (this.registeredHttpServer === server) {
+      return;
+    }
+
+    this.registeredHttpServer = server as ShutdownManagedServer;
+    this.registeredHttpServer.on('connection', (socket: Socket) => {
+      this.activeSockets.add(socket);
+      socket.once('close', () => {
+        this.activeSockets.delete(socket);
+      });
+    });
   }
 
   isShutdown(): boolean {
     return this.isShuttingDown;
   }
 
-  async onApplicationShutdown(signal?: string): Promise<void> {
-    this.logger.log(`Received shutdown signal: ${signal}`);
-    this.isShuttingDown = true;
-
-    const shutdownStartTime = Date.now();
-
-    // Stop accepting new requests
-    this.logger.log('Stopping acceptance of new requests');
-
-    // Wait for in-flight requests to complete
-    await this.waitForInFlightRequests();
-
-    // Close database connections
-    await this.closeDatabase();
-
-    // Close Redis connections
-    await this.closeRedis();
-
-    const shutdownDuration = Date.now() - shutdownStartTime;
-    this.logger.log(`Graceful shutdown completed in ${shutdownDuration}ms`);
+  getActiveRequestCount(): number {
+    return this.activeRequests;
   }
 
-  private async waitForInFlightRequests(): Promise<void> {
-    const startTime = Date.now();
-    const timeout = 25000; // Leave 5 seconds for other cleanup
+  getActiveBackgroundTaskCount(): number {
+    return this.activeBackgroundTasks;
+  }
 
-    while (this.activeRequests > 0) {
-      const elapsed = Date.now() - startTime;
+  incrementActiveRequests(): void {
+    if (this.isShuttingDown) {
+      return;
+    }
 
-      if (elapsed > timeout) {
+    this.activeRequests += 1;
+  }
+
+  decrementActiveRequests(): void {
+    this.activeRequests = Math.max(0, this.activeRequests - 1);
+  }
+
+  beginShutdown(signal?: string): void {
+    if (this.isShuttingDown) {
+      return;
+    }
+
+    this.isShuttingDown = true;
+    this.logger.warn(
+      `Graceful shutdown initiated${signal ? ` by ${signal}` : ''}`,
+    );
+  }
+
+  async shutdownApplication(
+    signal: NodeJS.Signals,
+    closeApplication: () => Promise<void>,
+    flushLogs?: () => Promise<void> | void,
+  ): Promise<number> {
+    if (this.shutdownPromise) {
+      return this.shutdownPromise;
+    }
+
+    this.beginShutdown(signal);
+
+    this.shutdownPromise = (async () => {
+      try {
+        await this.closeHttpServer();
+        await closeApplication();
+        await flushLogs?.();
+        return 0;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.stack ?? error.message : String(error);
+        this.logger.error(`Graceful shutdown failed: ${message}`);
+        await flushLogs?.();
+        return 1;
+      }
+    })();
+
+    return this.shutdownPromise;
+  }
+
+  async beforeApplicationShutdown(signal?: string): Promise<void> {
+    this.beginShutdown(signal);
+    this.stopSchedulers();
+    this.registeredHttpServer?.closeIdleConnections?.();
+
+    await this.waitForDrain(this.shutdownTimeoutMs - 5_000);
+    await this.closeCacheConnections();
+    await this.closeDatabaseConnections();
+  }
+
+  private async runBackgroundTask<T>(
+    taskName: string,
+    task: () => Promise<T> | T,
+  ): Promise<T | undefined> {
+    if (this.isShuttingDown) {
+      this.logger.warn(
+        `Skipping background task "${taskName}" because shutdown is in progress`,
+      );
+      return undefined;
+    }
+
+    this.activeBackgroundTasks += 1;
+
+    try {
+      return await task();
+    } finally {
+      this.activeBackgroundTasks = Math.max(0, this.activeBackgroundTasks - 1);
+    }
+  }
+
+  private async closeHttpServer(): Promise<void> {
+    if (!this.registeredHttpServer) {
+      return;
+    }
+
+    if (this.closeServerPromise) {
+      return this.closeServerPromise;
+    }
+
+    const server = this.registeredHttpServer;
+
+    this.closeServerPromise = new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(forceCloseTimer);
+        resolve();
+      };
+
+      const forceCloseTimer = setTimeout(() => {
         this.logger.warn(
-          `Timeout waiting for ${this.activeRequests} in-flight requests. Forcing shutdown.`,
+          'HTTP server drain timeout reached. Closing remaining sockets.',
         );
-        break;
+        server.closeAllConnections?.();
+        this.destroyOpenSockets();
+        finish();
+      }, this.shutdownTimeoutMs);
+
+      try {
+        server.close((error?: Error) => {
+          if (
+            error &&
+            (error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING'
+          ) {
+            this.logger.error(
+              `Error while closing HTTP server: ${error.message}`,
+            );
+          }
+          finish();
+        });
+        server.closeIdleConnections?.();
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING') {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          this.logger.error(`Failed to stop HTTP server: ${message}`);
+        }
+        finish();
+      }
+    });
+
+    return this.closeServerPromise;
+  }
+
+  private stopSchedulers(): void {
+    if (!this.schedulerRegistry || this.schedulersStopped) {
+      return;
+    }
+
+    this.schedulersStopped = true;
+
+    for (const [name, job] of this.schedulerRegistry.getCronJobs()) {
+      job.stop();
+      this.logger.log(`Stopped cron job "${name}"`);
+    }
+
+    for (const name of this.schedulerRegistry.getIntervals()) {
+      clearInterval(this.schedulerRegistry.getInterval(name));
+      this.schedulerRegistry.deleteInterval(name);
+      this.logger.log(`Cleared interval "${name}"`);
+    }
+
+    for (const name of this.schedulerRegistry.getTimeouts()) {
+      clearTimeout(this.schedulerRegistry.getTimeout(name));
+      this.schedulerRegistry.deleteTimeout(name);
+      this.logger.log(`Cleared timeout "${name}"`);
+    }
+  }
+
+  private async waitForDrain(timeoutMs: number): Promise<void> {
+    const startedAt = Date.now();
+
+    while (this.activeRequests > 0 || this.activeBackgroundTasks > 0) {
+      const elapsedMs = Date.now() - startedAt;
+      if (elapsedMs >= timeoutMs) {
+        this.logger.warn(
+          `Shutdown drain timed out with ${this.activeRequests} active request(s) and ${this.activeBackgroundTasks} active background task(s) remaining.`,
+        );
+        return;
       }
 
       this.logger.log(
-        `Waiting for ${this.activeRequests} in-flight requests to complete...`,
+        `Waiting for shutdown drain: ${this.activeRequests} active request(s), ${this.activeBackgroundTasks} active background task(s)`,
       );
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-
-    this.logger.log('All in-flight requests completed');
-  }
-
-  private async closeDatabase(): Promise<void> {
-    try {
-      if (this.dataSource && this.dataSource.isInitialized) {
-        this.logger.log('Closing database connections...');
-        await this.dataSource.destroy();
-        this.logger.log('Database connections closed');
-      }
-    } catch (error) {
-      this.logger.error('Error closing database connections:', error);
+      await this.delay(this.drainPollIntervalMs);
     }
   }
 
-  private async closeRedis(): Promise<void> {
+  private async closeDatabaseConnections(): Promise<void> {
+    if (!this.dataSource?.isInitialized) {
+      return;
+    }
+
     try {
-      if (this.cacheManager) {
-        this.logger.log('Closing Redis connections...');
-        // await this.cacheManager.reset(); // reset method not available
-        this.logger.log('Redis connections closed');
+      this.logger.log('Closing database connections');
+      await this.dataSource.destroy();
+      this.logger.log('Database connections closed');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Error closing database connections: ${message}`);
+    }
+  }
+
+  private async closeCacheConnections(): Promise<void> {
+    if (!this.cacheManager) {
+      return;
+    }
+
+    const manager = this.cacheManager as Cache & {
+      store?: {
+        client?: {
+          quit?: () => Promise<void>;
+          disconnect?: () => Promise<void>;
+        };
+      };
+      stores?: Array<{
+        client?: {
+          quit?: () => Promise<void>;
+          disconnect?: () => Promise<void>;
+        };
+      }>;
+    };
+
+    const store = manager.store ?? manager.stores?.[0];
+    const client = store?.client;
+
+    try {
+      if (client?.quit) {
+        this.logger.log('Closing cache connections');
+        await client.quit();
+        this.logger.log('Cache connections closed');
+        return;
+      }
+
+      if (client?.disconnect) {
+        this.logger.log('Disconnecting cache client');
+        await client.disconnect();
+        this.logger.log('Cache connections closed');
       }
     } catch (error) {
-      this.logger.error('Error closing Redis connections:', error);
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Error closing cache connections: ${message}`);
     }
+  }
+
+  private destroyOpenSockets(): void {
+    for (const socket of this.activeSockets) {
+      socket.destroy();
+    }
+    this.activeSockets.clear();
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/backend/src/common/services/idempotency-cleanup.service.ts
+++ b/backend/src/common/services/idempotency-cleanup.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { ShutdownTrackedTask } from '../decorators/shutdown-task.decorator';
 import { IdempotencyService } from './idempotency.service';
 
 @Injectable()
@@ -8,6 +9,7 @@ export class IdempotencyCleanupService {
 
   constructor(private readonly idempotencyService: IdempotencyService) {}
 
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   handleCleanup() {
     this.logger.log('Idempotency cleanup job running...');

--- a/backend/src/common/services/secrets-manager.service.ts
+++ b/backend/src/common/services/secrets-manager.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 interface SecretMetadata {
@@ -9,17 +9,25 @@ interface SecretMetadata {
 }
 
 @Injectable()
-export class SecretsManagerService implements OnModuleInit {
+export class SecretsManagerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(SecretsManagerService.name);
   private readonly secretsCache: Map<string, string> = new Map();
   private readonly secretsMetadata: Map<string, SecretMetadata> = new Map();
   private readonly SECRET_EXPIRY_DAYS = 90;
+  private expirationMonitor: NodeJS.Timeout | null = null;
 
   constructor(private configService: ConfigService) {}
 
   onModuleInit() {
     this.initializeSecrets();
     this.startExpirationMonitor();
+  }
+
+  onModuleDestroy() {
+    if (this.expirationMonitor) {
+      clearInterval(this.expirationMonitor);
+      this.expirationMonitor = null;
+    }
   }
 
   private initializeSecrets() {
@@ -86,7 +94,7 @@ export class SecretsManagerService implements OnModuleInit {
   }
 
   private startExpirationMonitor() {
-    setInterval(() => {
+    this.expirationMonitor = setInterval(() => {
       const expiring = this.getExpiringSecrets(30);
       if (expiring.length > 0) {
         this.logger.warn(`Found ${expiring.length} expiring secrets: ${expiring.map(s => s.key).join(', ')}`);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import {
+  INestApplication,
   ValidationPipe,
   VersioningType,
   BadRequestException,
@@ -16,6 +17,29 @@ import {
 import { VersionAnalyticsInterceptor } from './common/versioning/version-analytics.interceptor';
 import { VersionAnalyticsService } from './common/versioning/version-analytics.service';
 import { GracefulShutdownService } from './common/services/graceful-shutdown.service';
+
+async function flushApplicationLogs(
+  app: INestApplication,
+  logger: Logger,
+): Promise<void> {
+  const nestApp = app as INestApplication & {
+    flushLogs?: () => Promise<void> | void;
+  };
+
+  if (typeof nestApp.flushLogs === 'function') {
+    await nestApp.flushLogs();
+    return;
+  }
+
+  const pinoLogger = logger as Logger & {
+    flush?: () => void;
+    logger?: { flush?: () => void };
+  };
+
+  pinoLogger.flush?.();
+  pinoLogger.logger?.flush?.();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -160,8 +184,10 @@ The API supports URI-based versioning (\`/api/v1/...\` and \`/api/v2/...\`).
     res.redirect('/api/v2/docs');
   });
 
-  const server = await app.listen(port || 3001);
+  await app.listen(port || 3001);
   const logger = app.get(Logger);
+  const gracefulShutdown = app.get(GracefulShutdownService);
+  gracefulShutdown.registerHttpServer(app.getHttpServer());
   logger.log(`Application is running on: http://localhost:${port}/api`);
   logger.log(`Swagger docs (current):    http://localhost:${port}/api/docs`);
   logger.log(`Swagger v2 docs:           http://localhost:${port}/api/v2/docs`);
@@ -169,19 +195,20 @@ The API supports URI-based versioning (\`/api/v1/...\` and \`/api/v2/...\`).
     `Swagger v1 docs (deprecated): http://localhost:${port}/api/v1/docs`,
   );
 
-  // Setup graceful shutdown
-  const gracefulShutdown = app.get(GracefulShutdownService);
-
-  const signals = ['SIGTERM', 'SIGINT'];
-  signals.forEach((signal) => {
-    process.on(signal, async () => {
-      logger.log(`Received ${signal}, starting graceful shutdown...`);
-      server.close(async () => {
-        await app.close();
-        process.exit(0);
-      });
+  const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
+  for (const signal of signals) {
+    process.once(signal, () => {
+      void gracefulShutdown
+        .shutdownApplication(
+          signal,
+          () => app.close(),
+          () => flushApplicationLogs(app, logger),
+        )
+        .then((exitCode) => {
+          process.exit(exitCode);
+        });
     });
-  });
+  }
 
   // Handle uncaught exceptions
   process.on('uncaughtException', (error) => {

--- a/backend/src/modules/admin-analytics/admin-analytics.service.ts
+++ b/backend/src/modules/admin-analytics/admin-analytics.service.ts
@@ -26,6 +26,7 @@ import {
   DateRangeFilterDto,
   DateRange,
 } from '../admin/dto/admin-analytics.dto';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 @Injectable()
 export class AdminAnalyticsService {
@@ -92,6 +93,7 @@ export class AdminAnalyticsService {
    * Cron job that runs daily at 12:00 UTC to snapshot global TVL
    * Schedule: 0 0 12 * * * (12:00 UTC every day)
    */
+  @ShutdownTrackedTask()
   @Cron('0 0 12 * * *')
   async snapshotGlobalTvl(): Promise<void> {
     this.logger.log('Starting global TVL snapshot job...');

--- a/backend/src/modules/admin/admin-audit-logs-archival.service.ts
+++ b/backend/src/modules/admin/admin-audit-logs-archival.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { AuditLog } from '../../common/entities/audit-log.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 const pipelineAsync = promisify(pipeline);
 
@@ -77,6 +78,7 @@ export class AdminAuditLogsArchivalService {
   /**
    * Daily archival job — runs at 01:00 UTC
    */
+  @ShutdownTrackedTask()
   @Cron('0 1 * * *')
   async archiveOldLogs(): Promise<void> {
     try {

--- a/backend/src/modules/admin/admin-notifications.service.ts
+++ b/backend/src/modules/admin/admin-notifications.service.ts
@@ -13,6 +13,8 @@ import {
 } from '../savings/entities/user-subscription.entity';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bullmq';
+import { MailService } from '../mail/mail.service';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 import {
   BroadcastNotificationDto,
   ScheduleNotificationDto,
@@ -330,6 +332,7 @@ export class AdminNotificationsService {
    * Scheduled job to process scheduled notifications
    * Runs every minute to check for pending scheduled notifications
    */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_MINUTE)
   async processScheduledNotifications(): Promise<void> {
     const now = new Date();

--- a/backend/src/modules/alerts/alerts.service.ts
+++ b/backend/src/modules/alerts/alerts.service.ts
@@ -10,6 +10,7 @@ import { User } from '../user/entities/user.entity';
 import { CreateAlertDto } from './dto/create-alert.dto';
 import { AlertHistory } from './entities/alert-history.entity';
 import { AlertType, ProductAlert } from './entities/product-alert.entity';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 @Injectable()
 export class AlertsService {
@@ -101,6 +102,7 @@ export class AlertsService {
   }
 
   // Periodic condition evaluator for product alerts.
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_10_MINUTES)
   async evaluateAlerts() {
     const now = new Date();

--- a/backend/src/modules/apm/apm.service.ts
+++ b/backend/src/modules/apm/apm.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MetricsService } from './metrics.service';
 import { DistributedTracingService, TraceContext } from './distributed-tracing.service';
@@ -28,7 +28,7 @@ export interface AlertRule {
 }
 
 @Injectable()
-export class ApmService implements OnModuleInit {
+export class ApmService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(ApmService.name);
   private readonly errorRegistry = new Map<string, ErrorEvent>();
   private readonly alertRules: AlertRule[] = [];
@@ -38,6 +38,7 @@ export class ApmService implements OnModuleInit {
     timestamp: Date;
     severity: string;
   }> = [];
+  private alertEvaluationTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly metricsService: MetricsService,
@@ -48,6 +49,13 @@ export class ApmService implements OnModuleInit {
   onModuleInit() {
     this.setupDefaultAlertRules();
     this.startAlertEvaluationLoop();
+  }
+
+  onModuleDestroy(): void {
+    if (this.alertEvaluationTimer) {
+      clearInterval(this.alertEvaluationTimer);
+      this.alertEvaluationTimer = null;
+    }
   }
 
   private setupDefaultAlertRules() {
@@ -83,7 +91,7 @@ export class ApmService implements OnModuleInit {
   }
 
   private startAlertEvaluationLoop() {
-    setInterval(() => {
+    this.alertEvaluationTimer = setInterval(() => {
       this.evaluateAlerts();
     }, 60_000);
   }

--- a/backend/src/modules/backup/backup-monitor.service.ts
+++ b/backend/src/modules/backup/backup-monitor.service.ts
@@ -3,6 +3,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { MailService } from '../mail/mail.service';
 import { BackupService } from './backup.service';
 import { BackupStatus } from './entities/backup-record.entity';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 const MAX_BACKUP_AGE_HOURS = 26; // alert if no successful backup in 26h
 
@@ -16,6 +17,7 @@ export class BackupMonitorService {
   ) {}
 
   // Check every hour
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_HOUR)
   async checkBackupFreshness(): Promise<void> {
     const latest = await this.backupService.getLastSuccessful();
@@ -40,6 +42,7 @@ export class BackupMonitorService {
   }
 
   // Check for failed backups — runs 30 min after the daily backup window
+  @ShutdownTrackedTask()
   @Cron('30 2 * * *')
   async checkLastBackupResult(): Promise<void> {
     const records = await this.backupService.getRecentBackups(1);

--- a/backend/src/modules/backup/backup-restore-test.service.ts
+++ b/backend/src/modules/backup/backup-restore-test.service.ts
@@ -12,6 +12,7 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 import { BackupRecord, BackupStatus } from './entities/backup-record.entity';
 import { BackupService } from './backup.service';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 const execAsync = promisify(exec);
 
@@ -46,6 +47,7 @@ export class BackupRestoreTestService {
   }
 
   // First Sunday of every month at 04:00 UTC
+  @ShutdownTrackedTask()
   @Cron('0 4 1-7 * 0')
   async runMonthlyRestoreTest(): Promise<void> {
     this.logger.log('Starting monthly restore test...');

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -15,6 +15,7 @@ import {
   ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
 import { BackupRecord, BackupStatus } from './entities/backup-record.entity';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 const execAsync = promisify(exec);
 
@@ -50,6 +51,7 @@ export class BackupService {
   }
 
   // Daily at 02:00 UTC
+  @ShutdownTrackedTask()
   @Cron('0 2 * * *')
   async runDailyBackup(): Promise<BackupRecord> {
     this.logger.log('Starting daily database backup...');
@@ -98,6 +100,7 @@ export class BackupService {
   }
 
   // Purge backups older than retention window — runs daily at 03:00 UTC
+  @ShutdownTrackedTask()
   @Cron('0 3 * * *')
   async purgeExpiredBackups(): Promise<void> {
     const expired = await this.backupRepo

--- a/backend/src/modules/blockchain/indexer.service.ts
+++ b/backend/src/modules/blockchain/indexer.service.ts
@@ -11,6 +11,7 @@ import { WithdrawHandler } from './event-handlers/withdraw.handler';
 import { YieldHandler } from './event-handlers/yield.handler';
 import { StellarService } from './stellar.service';
 import { SavingsProduct } from '../savings/entities/savings-product.entity';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 /** Shape of a raw Soroban event as returned by the RPC. */
 interface SorobanEvent {
@@ -61,6 +62,7 @@ export class IndexerService implements OnModuleInit {
     );
   }
 
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_5_SECONDS)
   async runIndexerCycle(): Promise<void> {
     if (!this.indexerState) return;

--- a/backend/src/modules/notifications/governance-notification.scheduler.ts
+++ b/backend/src/modules/notifications/governance-notification.scheduler.ts
@@ -17,6 +17,7 @@ import {
 import { Vote } from '../governance/entities/vote.entity';
 import { MailService } from '../mail/mail.service';
 import { StellarService } from '../blockchain/stellar.service';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 @Injectable()
 export class GovernanceNotificationScheduler {
@@ -41,6 +42,7 @@ export class GovernanceNotificationScheduler {
   /**
    * Daily Digest: Every day at midnight
    */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async handleDailyDigest() {
     this.logger.log('Starting Daily Governance Digest...');
@@ -50,6 +52,7 @@ export class GovernanceNotificationScheduler {
   /**
    * Weekly Digest: Every Monday at midnight
    */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_WEEKEND)
   async handleWeeklyDigest() {
     this.logger.log('Starting Weekly Governance Digest...');
@@ -60,6 +63,7 @@ export class GovernanceNotificationScheduler {
    * Voting Reminders: Every hour
    * Notifies users who haven't voted on proposals closing in ~24 hours
    */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_HOUR)
   async handleVotingReminders() {
     this.logger.log('Checking for upcoming voting deadlines...');

--- a/backend/src/modules/notifications/milestone-scheduler.service.ts
+++ b/backend/src/modules/notifications/milestone-scheduler.service.ts
@@ -8,6 +8,7 @@ import {
   SavingsGoalStatus,
 } from '../savings/entities/savings-goal.entity';
 import { SavingsService } from '../savings/savings.service';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 @Injectable()
 export class MilestoneSchedulerService {
@@ -24,6 +25,7 @@ export class MilestoneSchedulerService {
   ) {}
 
   // Run daily at midnight UTC
+  @ShutdownTrackedTask()
   @Cron('0 0 0 * * *')
   async handleDailyMilestones() {
     this.logger.log('Running daily milestone scheduler');

--- a/backend/src/modules/savings/services/auto-deposit.service.ts
+++ b/backend/src/modules/savings/services/auto-deposit.service.ts
@@ -14,6 +14,7 @@ import {
 } from '../entities/auto-deposit-schedule.entity';
 import { CreateAutoDepositDto } from '../dto/auto-deposit.dto';
 import { SavingsService } from '../savings.service';
+import { ShutdownTrackedTask } from '../../../common/decorators/shutdown-task.decorator';
 
 const MAX_RETRIES = 5;
 
@@ -63,6 +64,7 @@ export class AutoDepositService {
   }
 
   /** Runs every minute; processes due schedules */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_MINUTE)
   async processDueSchedules(): Promise<void> {
     const now = new Date();

--- a/backend/src/modules/savings/services/interest-calculation.service.ts
+++ b/backend/src/modules/savings/services/interest-calculation.service.ts
@@ -10,6 +10,7 @@ import {
 } from '../entities/user-subscription.entity';
 import { InterestHistory } from '../entities/interest-history.entity';
 import { SavingsProductType } from '../entities/savings-product.entity';
+import { ShutdownTrackedTask } from '../../../common/decorators/shutdown-task.decorator';
 
 export interface InterestCreditedEvent {
   userId: string;
@@ -37,6 +38,7 @@ export class InterestCalculationService {
    * Runs daily at midnight UTC.
    * Calculates and distributes daily accrued interest for all active subscriptions.
    */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: 'UTC' })
   async runDailyInterestCalculation(): Promise<void> {
     const runId = uuidv4();

--- a/backend/src/modules/sweep/sweep-tasks.service.ts
+++ b/backend/src/modules/sweep/sweep-tasks.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { UserService } from '../user/user.service';
 import { StellarService } from '../blockchain/stellar.service';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 @Injectable()
 export class SweepTasksService {
@@ -13,6 +14,7 @@ export class SweepTasksService {
   ) {}
 
   // Runs every minute; adjust schedule as needed
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_MINUTE)
   async handleSweep() {
     this.logger.log('Starting sweep job');

--- a/backend/src/modules/user/sweep-tasks.service.ts
+++ b/backend/src/modules/user/sweep-tasks.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { User } from './entities/user.entity';
 import { StellarService } from '../blockchain/stellar.service';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 @Injectable()
 export class SweepTasksService {
@@ -21,6 +22,7 @@ export class SweepTasksService {
    * Cron job that runs every hour to check and execute account sweeps
    * Schedule: Every hour at minute 0
    */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_HOUR)
   async handleAccountSweep() {
     this.logger.log('Starting account sweep job...');

--- a/backend/src/modules/webhooks/webhook-retry.scheduler.ts
+++ b/backend/src/modules/webhooks/webhook-retry.scheduler.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { WebhookService } from './webhook.service';
+import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
 @Injectable()
 export class WebhookRetryScheduler {
@@ -9,6 +10,7 @@ export class WebhookRetryScheduler {
   constructor(private readonly webhookService: WebhookService) {}
 
   /** Run every minute to pick up deliveries whose nextRetryAt has passed */
+  @ShutdownTrackedTask()
   @Cron(CronExpression.EVERY_MINUTE)
   async handleRetries(): Promise<void> {
     try {


### PR DESCRIPTION
Closes: #903

## Summary

This PR implements graceful shutdown handling for the backend so rolling deployments and process termination behave predictably.

### What changed

- Added coordinated `SIGTERM` / `SIGINT` shutdown handling in `backend/src/main.ts`
- Refactored `GracefulShutdownService` to:
  - mark shutdown state
  - stop accepting new connections
  - drain in-flight requests with a timeout
  - track running background jobs
  - stop schedulers/intervals/timeouts
  - close database connections gracefully
  - close cache/Redis connections when available
  - force-close lingering sockets if drain timeout is exceeded
- Added a reusable `ShutdownTrackedTask` decorator and applied it to scheduled jobs so shutdown waits for running background work to finish
- Updated the shutdown interceptor to return `503` and close the connection during shutdown
- Cleared long-lived non-cron intervals in services that previously left timers running
- Fixed `AppModule` wiring needed for the shutdown path to be reachable
- Added targeted unit specs for the shutdown service and interceptor

## Acceptance criteria mapping

- [x] Add SIGTERM/SIGINT handlers
- [x] Implement connection draining
- [x] Close database connections gracefully
- [x] Stop accepting new requests on shutdown
- [x] Complete in-flight requests (with timeout)
- [x] Flush logs before exit
- [x] Cover rollout-oriented shutdown behavior in code/tests

## Notes

- I did not install dependencies or run package-based tests per request.
- Verification was limited to code inspection, staged diff checks, and targeted test additions.
- Branch pushed: `codex-graceful-shutdown-handling`
- Commit: `5f6dec24`