### PR TITLE
Add savings goal sharing backend

### DIFF
--- a/backend/src/migrations/1800200000000-CreateSavingsGoalSharingTables.ts
+++ b/backend/src/migrations/1800200000000-CreateSavingsGoalSharingTables.ts
@@ -1,0 +1,218 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateSavingsGoalSharingTables1800200000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'savings_goal_shares',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'goalId', type: 'uuid', isNullable: false },
+          { name: 'ownerId', type: 'uuid', isNullable: false },
+          {
+            name: 'visibility',
+            type: 'enum',
+            enum: ['PRIVATE', 'FRIENDS', 'PUBLIC', 'UNLISTED'],
+            default: "'PRIVATE'",
+            isNullable: false,
+          },
+          {
+            name: 'shareToken',
+            type: 'varchar',
+            length: '80',
+            isNullable: true,
+          },
+          { name: 'expiresAt', type: 'timestamp', isNullable: true },
+          { name: 'revokedAt', type: 'timestamp', isNullable: true },
+          {
+            name: 'isDirectoryListed',
+            type: 'boolean',
+            default: false,
+            isNullable: false,
+          },
+          {
+            name: 'showProgress',
+            type: 'boolean',
+            default: true,
+            isNullable: false,
+          },
+          {
+            name: 'showTargetAmount',
+            type: 'boolean',
+            default: false,
+            isNullable: false,
+          },
+          {
+            name: 'showOwnerName',
+            type: 'boolean',
+            default: true,
+            isNullable: false,
+          },
+          {
+            name: 'allowSocialSharing',
+            type: 'boolean',
+            default: true,
+            isNullable: false,
+          },
+          {
+            name: 'allowProgressUpdates',
+            type: 'boolean',
+            default: true,
+            isNullable: false,
+          },
+          { name: 'allowedUserIds', type: 'jsonb', isNullable: true },
+          { name: 'metadata', type: 'jsonb', isNullable: true },
+          { name: 'createdAt', type: 'timestamp', default: 'now()' },
+          { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createForeignKey(
+      'savings_goal_shares',
+      new TableForeignKey({
+        columnNames: ['goalId'],
+        referencedTableName: 'savings_goals',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'savings_goal_shares',
+      new TableForeignKey({
+        columnNames: ['ownerId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'savings_goal_shares',
+      new TableIndex({
+        name: 'IDX_SAVINGS_GOAL_SHARES_GOAL_ID',
+        columnNames: ['goalId'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'savings_goal_shares',
+      new TableIndex({
+        name: 'IDX_SAVINGS_GOAL_SHARES_TOKEN',
+        columnNames: ['shareToken'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'savings_goal_shares',
+      new TableIndex({
+        name: 'IDX_SAVINGS_GOAL_SHARES_DIRECTORY',
+        columnNames: ['visibility', 'isDirectoryListed'],
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'savings_goal_share_events',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'shareId', type: 'uuid', isNullable: false },
+          { name: 'goalId', type: 'uuid', isNullable: false },
+          { name: 'viewerId', type: 'uuid', isNullable: true },
+          {
+            name: 'eventType',
+            type: 'enum',
+            enum: [
+              'LINK_CREATED',
+              'VIEW',
+              'DIRECTORY_VIEW',
+              'SOCIAL_SHARE',
+              'PROGRESS_UPDATE',
+              'PERMISSION_UPDATED',
+              'REVOKED',
+            ],
+            isNullable: false,
+          },
+          { name: 'platform', type: 'varchar', length: '32', isNullable: true },
+          { name: 'metadata', type: 'jsonb', isNullable: true },
+          { name: 'createdAt', type: 'timestamp', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createForeignKey(
+      'savings_goal_share_events',
+      new TableForeignKey({
+        columnNames: ['shareId'],
+        referencedTableName: 'savings_goal_shares',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'savings_goal_share_events',
+      new TableForeignKey({
+        columnNames: ['goalId'],
+        referencedTableName: 'savings_goals',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'savings_goal_share_events',
+      new TableForeignKey({
+        columnNames: ['viewerId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+    );
+
+    for (const index of [
+      new TableIndex({
+        name: 'IDX_SAVINGS_GOAL_SHARE_EVENTS_SHARE_ID',
+        columnNames: ['shareId'],
+      }),
+      new TableIndex({
+        name: 'IDX_SAVINGS_GOAL_SHARE_EVENTS_GOAL_ID',
+        columnNames: ['goalId'],
+      }),
+      new TableIndex({
+        name: 'IDX_SAVINGS_GOAL_SHARE_EVENTS_TYPE',
+        columnNames: ['eventType'],
+      }),
+    ]) {
+      await queryRunner.createIndex('savings_goal_share_events', index);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('savings_goal_share_events');
+    await queryRunner.dropTable('savings_goal_shares');
+  }
+}

--- a/backend/src/modules/savings/dto/goal-sharing.dto.ts
+++ b/backend/src/modules/savings/dto/goal-sharing.dto.ts
@@ -1,0 +1,86 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { SavingsGoalShareVisibility } from '../entities/savings-goal-share.entity';
+
+export class UpdateGoalSharingDto {
+  @ApiProperty({ enum: SavingsGoalShareVisibility })
+  @IsEnum(SavingsGoalShareVisibility)
+  visibility: SavingsGoalShareVisibility;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  isDirectoryListed?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  showProgress?: boolean;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  showTargetAmount?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  showOwnerName?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  allowSocialSharing?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  allowProgressUpdates?: boolean;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(100)
+  @IsUUID('4', { each: true })
+  allowedUserIds?: string[];
+}
+
+export class CreateShareLinkDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string;
+}
+
+export class PublicGoalDirectoryQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  page?: number;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  limit?: number;
+}
+
+export class SocialShareDto {
+  @ApiProperty({ enum: ['x', 'facebook', 'linkedin', 'whatsapp', 'copy'] })
+  @IsIn(['x', 'facebook', 'linkedin', 'whatsapp', 'copy'])
+  platform: 'x' | 'facebook' | 'linkedin' | 'whatsapp' | 'copy';
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  message?: string;
+}

--- a/backend/src/modules/savings/entities/savings-goal-share-event.entity.ts
+++ b/backend/src/modules/savings/entities/savings-goal-share-event.entity.ts
@@ -1,0 +1,67 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { SavingsGoalShare } from './savings-goal-share.entity';
+import { SavingsGoal } from './savings-goal.entity';
+import { User } from '../../user/entities/user.entity';
+
+export enum SavingsGoalShareEventType {
+  LINK_CREATED = 'LINK_CREATED',
+  VIEW = 'VIEW',
+  DIRECTORY_VIEW = 'DIRECTORY_VIEW',
+  SOCIAL_SHARE = 'SOCIAL_SHARE',
+  PROGRESS_UPDATE = 'PROGRESS_UPDATE',
+  PERMISSION_UPDATED = 'PERMISSION_UPDATED',
+  REVOKED = 'REVOKED',
+}
+
+@Entity('savings_goal_share_events')
+@Index('IDX_SAVINGS_GOAL_SHARE_EVENTS_SHARE_ID', ['shareId'])
+@Index('IDX_SAVINGS_GOAL_SHARE_EVENTS_GOAL_ID', ['goalId'])
+@Index('IDX_SAVINGS_GOAL_SHARE_EVENTS_TYPE', ['eventType'])
+export class SavingsGoalShareEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  shareId: string;
+
+  @Column('uuid')
+  goalId: string;
+
+  @Column('uuid', { nullable: true })
+  viewerId: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: SavingsGoalShareEventType,
+  })
+  eventType: SavingsGoalShareEventType;
+
+  @Column({ type: 'varchar', length: 32, nullable: true })
+  platform: string | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => SavingsGoalShare, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'shareId' })
+  share: SavingsGoalShare;
+
+  @ManyToOne(() => SavingsGoal, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'goalId' })
+  goal: SavingsGoal;
+
+  @ManyToOne(() => User, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'viewerId' })
+  viewer: User | null;
+}

--- a/backend/src/modules/savings/entities/savings-goal-share.entity.ts
+++ b/backend/src/modules/savings/entities/savings-goal-share.entity.ts
@@ -1,0 +1,88 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { SavingsGoal } from './savings-goal.entity';
+import { User } from '../../user/entities/user.entity';
+
+export enum SavingsGoalShareVisibility {
+  PRIVATE = 'PRIVATE',
+  FRIENDS = 'FRIENDS',
+  PUBLIC = 'PUBLIC',
+  UNLISTED = 'UNLISTED',
+}
+
+@Entity('savings_goal_shares')
+@Index('IDX_SAVINGS_GOAL_SHARES_GOAL_ID', ['goalId'], { unique: true })
+@Index('IDX_SAVINGS_GOAL_SHARES_TOKEN', ['shareToken'], { unique: true })
+@Index('IDX_SAVINGS_GOAL_SHARES_DIRECTORY', ['visibility', 'isDirectoryListed'])
+export class SavingsGoalShare {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  goalId: string;
+
+  @Column('uuid')
+  ownerId: string;
+
+  @Column({
+    type: 'enum',
+    enum: SavingsGoalShareVisibility,
+    default: SavingsGoalShareVisibility.PRIVATE,
+  })
+  visibility: SavingsGoalShareVisibility;
+
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  shareToken: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expiresAt: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  revokedAt: Date | null;
+
+  @Column({ type: 'boolean', default: false })
+  isDirectoryListed: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  showProgress: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  showTargetAmount: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  showOwnerName: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  allowSocialSharing: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  allowProgressUpdates: boolean;
+
+  @Column({ type: 'jsonb', nullable: true })
+  allowedUserIds: string[] | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne(() => SavingsGoal, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'goalId' })
+  goal: SavingsGoal;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'ownerId' })
+  owner: User;
+}

--- a/backend/src/modules/savings/savings-goal-sharing.controller.ts
+++ b/backend/src/modules/savings/savings-goal-sharing.controller.ts
@@ -1,0 +1,145 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../../auth/guards/optional-jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import {
+  CreateShareLinkDto,
+  PublicGoalDirectoryQueryDto,
+  SocialShareDto,
+  UpdateGoalSharingDto,
+} from './dto/goal-sharing.dto';
+import { SavingsGoalSharingService } from './savings-goal-sharing.service';
+
+@ApiTags('savings-goal-sharing')
+@Controller('savings')
+export class SavingsGoalSharingController {
+  constructor(private readonly sharingService: SavingsGoalSharingService) {}
+
+  @Patch('goals/:id/share')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create or update sharing permissions for a goal' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async updateSharing(
+    @Param('id') id: string,
+    @Body() dto: UpdateGoalSharingDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.sharingService.upsertSharing(id, user.id, dto);
+  }
+
+  @Get('goals/:id/share')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get sharing permissions for a goal' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async getSharing(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.sharingService.getSharing(id, user.id);
+  }
+
+  @Post('goals/:id/share/link')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a shareable link for a goal' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async createShareLink(
+    @Param('id') id: string,
+    @Body() dto: CreateShareLinkDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.sharingService.createShareLink(id, user.id, dto.expiresAt);
+  }
+
+  @Delete('goals/:id/share')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Revoke sharing for a goal' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async revokeSharing(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.sharingService.revokeShare(id, user.id);
+  }
+
+  @Get('share/:token')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'Resolve a public or friend-permitted share link' })
+  @ApiParam({ name: 'token', type: 'string' })
+  async getSharedGoal(
+    @Param('token') token: string,
+    @CurrentUser() user?: { id: string },
+  ) {
+    return this.sharingService.getSharedGoalByToken(token, user?.id);
+  }
+
+  @Get('public-goals')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'List publicly shared savings goals' })
+  @ApiResponse({ status: 200, description: 'Public savings goal directory' })
+  async getPublicGoals(
+    @Query() query: PublicGoalDirectoryQueryDto,
+    @CurrentUser() user?: { id: string },
+  ) {
+    return this.sharingService.getDirectory(query.page, query.limit, user?.id);
+  }
+
+  @Get('goals/:id/share/progress')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'Get a shared goal progress update' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async getProgressUpdate(
+    @Param('id') id: string,
+    @CurrentUser() user?: { id: string },
+  ) {
+    return this.sharingService.getProgressUpdate(id, user?.id);
+  }
+
+  @Post('goals/:id/share/social')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a social share intent for a goal' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async createSocialShare(
+    @Param('id') id: string,
+    @Body() dto: SocialShareDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.sharingService.createSocialShare(id, user.id, dto);
+  }
+
+  @Get('goals/:id/share/analytics')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get sharing analytics for a goal' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async getAnalytics(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.sharingService.getAnalytics(id, user.id);
+  }
+}

--- a/backend/src/modules/savings/savings-goal-sharing.service.spec.ts
+++ b/backend/src/modules/savings/savings-goal-sharing.service.spec.ts
@@ -1,0 +1,238 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SavingsGoalSharingService } from './savings-goal-sharing.service';
+import { SavingsGoal, SavingsGoalStatus } from './entities/savings-goal.entity';
+import {
+  SavingsGoalShare,
+  SavingsGoalShareVisibility,
+} from './entities/savings-goal-share.entity';
+import {
+  SavingsGoalShareEvent,
+  SavingsGoalShareEventType,
+} from './entities/savings-goal-share-event.entity';
+import { SavingsService } from './savings.service';
+
+const goal = {
+  id: '11111111-1111-4111-8111-111111111111',
+  userId: '22222222-2222-4222-8222-222222222222',
+  goalName: 'Emergency fund',
+  targetAmount: 5000,
+  targetDate: new Date('2027-01-01'),
+  status: SavingsGoalStatus.IN_PROGRESS,
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as SavingsGoal;
+
+const owner = {
+  id: goal.userId,
+  name: 'Ada',
+};
+
+function createShare(overrides: Partial<SavingsGoalShare> = {}) {
+  return {
+    id: '33333333-3333-4333-8333-333333333333',
+    goalId: goal.id,
+    ownerId: owner.id,
+    visibility: SavingsGoalShareVisibility.PUBLIC,
+    shareToken: 'share-token',
+    expiresAt: null,
+    revokedAt: null,
+    isDirectoryListed: false,
+    showProgress: true,
+    showTargetAmount: false,
+    showOwnerName: true,
+    allowSocialSharing: true,
+    allowProgressUpdates: true,
+    allowedUserIds: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    goal,
+    owner,
+    ...overrides,
+  } as SavingsGoalShare;
+}
+
+describe('SavingsGoalSharingService', () => {
+  let service: SavingsGoalSharingService;
+  let goalRepository: { findOne: jest.Mock };
+  let shareRepository: {
+    findOne: jest.Mock;
+    findAndCount: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+  let eventRepository: {
+    find: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    goalRepository = {
+      findOne: jest.fn().mockResolvedValue(goal),
+    };
+    shareRepository = {
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+      create: jest.fn((value) => value),
+      save: jest.fn(async (value) => ({
+        id: value.id ?? '33333333-3333-4333-8333-333333333333',
+        createdAt: value.createdAt ?? new Date(),
+        updatedAt: new Date(),
+        ...value,
+      })),
+    };
+    eventRepository = {
+      find: jest.fn().mockResolvedValue([]),
+      create: jest.fn((value) => value),
+      save: jest.fn(async (value) => value),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SavingsGoalSharingService,
+        {
+          provide: getRepositoryToken(SavingsGoal),
+          useValue: goalRepository,
+        },
+        {
+          provide: getRepositoryToken(SavingsGoalShare),
+          useValue: shareRepository,
+        },
+        {
+          provide: getRepositoryToken(SavingsGoalShareEvent),
+          useValue: eventRepository,
+        },
+        {
+          provide: SavingsService,
+          useValue: {
+            findMyGoals: jest.fn().mockResolvedValue([
+              {
+                ...goal,
+                targetAmount: 5000,
+                currentBalance: 1500,
+                percentageComplete: 30,
+                projectedBalance: 5200,
+                isOffTrack: false,
+                projectionGap: 0,
+                appliedYieldRate: 4.5,
+              },
+            ]),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) =>
+              key === 'PUBLIC_APP_URL' ? 'https://app.nestera.test' : undefined,
+            ),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SavingsGoalSharingService);
+  });
+
+  it('creates public sharing settings with directory listing', async () => {
+    shareRepository.findOne.mockResolvedValue(null);
+
+    const result = await service.upsertSharing(goal.id, owner.id, {
+      visibility: SavingsGoalShareVisibility.PUBLIC,
+      isDirectoryListed: true,
+      showTargetAmount: true,
+    });
+
+    expect(result.visibility).toBe(SavingsGoalShareVisibility.PUBLIC);
+    expect(result.isDirectoryListed).toBe(true);
+    expect(result.showTargetAmount).toBe(true);
+    expect(eventRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: SavingsGoalShareEventType.PERMISSION_UPDATED,
+      }),
+    );
+  });
+
+  it('blocks directory listing for non-public shares', async () => {
+    await expect(
+      service.upsertSharing(goal.id, owner.id, {
+        visibility: SavingsGoalShareVisibility.FRIENDS,
+        isDirectoryListed: true,
+      }),
+    ).rejects.toThrow('Only public goals can be listed');
+  });
+
+  it('creates a shareable link and returns the public URL', async () => {
+    shareRepository.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const result = await service.createShareLink(goal.id, owner.id);
+
+    expect(result.share.shareToken).toEqual(expect.any(String));
+    expect(result.shareUrl).toContain('https://app.nestera.test/goals/shared/');
+    expect(result.share.visibility).toBe(SavingsGoalShareVisibility.UNLISTED);
+  });
+
+  it('returns a redacted shared goal and records views', async () => {
+    shareRepository.findOne.mockResolvedValue(
+      createShare({ showTargetAmount: false }),
+    );
+
+    const result = await service.getSharedGoalByToken('share-token');
+
+    expect(result.goal.targetAmount).toBeUndefined();
+    expect(result.goal.percentageComplete).toBe(30);
+    expect(eventRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: SavingsGoalShareEventType.VIEW,
+      }),
+    );
+  });
+
+  it('denies friend-only shares to users outside the allow list', async () => {
+    shareRepository.findOne.mockResolvedValue(
+      createShare({
+        visibility: SavingsGoalShareVisibility.FRIENDS,
+        allowedUserIds: ['44444444-4444-4444-8444-444444444444'],
+      }),
+    );
+
+    await expect(
+      service.getSharedGoalByToken(
+        'share-token',
+        '55555555-5555-4555-8555-555555555555',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('builds social share intents and aggregates analytics', async () => {
+    shareRepository.findOne.mockResolvedValue(createShare());
+    eventRepository.find.mockResolvedValue([
+      {
+        eventType: SavingsGoalShareEventType.VIEW,
+        viewerId: null,
+        platform: null,
+      },
+      {
+        eventType: SavingsGoalShareEventType.SOCIAL_SHARE,
+        viewerId: owner.id,
+        platform: 'x',
+      },
+    ]);
+
+    const social = await service.createSocialShare(goal.id, owner.id, {
+      platform: 'x',
+    });
+    const analytics = await service.getAnalytics(goal.id, owner.id);
+
+    expect(social.intentUrl).toContain('twitter.com/intent/tweet');
+    expect(analytics.totalViews).toBe(1);
+    expect(analytics.socialShares).toBe(1);
+    expect(analytics.byPlatform.x).toBe(1);
+  });
+});

--- a/backend/src/modules/savings/savings-goal-sharing.service.ts
+++ b/backend/src/modules/savings/savings-goal-sharing.service.ts
@@ -1,0 +1,493 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { randomBytes } from 'crypto';
+import { IsNull, MoreThan, Repository } from 'typeorm';
+import { SavingsGoal } from './entities/savings-goal.entity';
+import {
+  SavingsGoalShare,
+  SavingsGoalShareVisibility,
+} from './entities/savings-goal-share.entity';
+import {
+  SavingsGoalShareEvent,
+  SavingsGoalShareEventType,
+} from './entities/savings-goal-share-event.entity';
+import { SavingsService, SavingsGoalProgress } from './savings.service';
+import { SocialShareDto, UpdateGoalSharingDto } from './dto/goal-sharing.dto';
+
+interface SharedGoalResponse {
+  goal: {
+    id: string;
+    goalName: string;
+    targetDate: Date;
+    status: SavingsGoal['status'];
+    metadata: SavingsGoal['metadata'];
+    targetAmount?: number;
+    currentBalance?: number;
+    percentageComplete?: number;
+    projectedBalance?: number;
+    isOffTrack?: boolean;
+    projectionGap?: number;
+  };
+  owner: {
+    id: string;
+    name?: string | null;
+  };
+  share: SavingsGoalShare;
+}
+
+@Injectable()
+export class SavingsGoalSharingService {
+  constructor(
+    @InjectRepository(SavingsGoal)
+    private readonly goalRepository: Repository<SavingsGoal>,
+    @InjectRepository(SavingsGoalShare)
+    private readonly shareRepository: Repository<SavingsGoalShare>,
+    @InjectRepository(SavingsGoalShareEvent)
+    private readonly eventRepository: Repository<SavingsGoalShareEvent>,
+    private readonly savingsService: SavingsService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async upsertSharing(
+    goalId: string,
+    ownerId: string,
+    dto: UpdateGoalSharingDto,
+  ): Promise<SavingsGoalShare> {
+    await this.assertGoalOwner(goalId, ownerId);
+
+    if (
+      dto.visibility !== SavingsGoalShareVisibility.PUBLIC &&
+      dto.isDirectoryListed
+    ) {
+      throw new BadRequestException(
+        'Only public goals can be listed in the public directory',
+      );
+    }
+
+    let share = await this.shareRepository.findOne({ where: { goalId } });
+    if (!share) {
+      share = this.shareRepository.create({ goalId, ownerId });
+    }
+
+    Object.assign(share, {
+      visibility: dto.visibility,
+      isDirectoryListed:
+        dto.isDirectoryListed ?? share.isDirectoryListed ?? false,
+      showProgress: dto.showProgress ?? share.showProgress ?? true,
+      showTargetAmount: dto.showTargetAmount ?? share.showTargetAmount ?? false,
+      showOwnerName: dto.showOwnerName ?? share.showOwnerName ?? true,
+      allowSocialSharing:
+        dto.allowSocialSharing ?? share.allowSocialSharing ?? true,
+      allowProgressUpdates:
+        dto.allowProgressUpdates ?? share.allowProgressUpdates ?? true,
+      allowedUserIds: dto.allowedUserIds ?? share.allowedUserIds ?? null,
+      revokedAt:
+        dto.visibility === SavingsGoalShareVisibility.PRIVATE
+          ? (share.revokedAt ?? new Date())
+          : null,
+    });
+
+    const saved = await this.shareRepository.save(share);
+    await this.recordEvent(saved, SavingsGoalShareEventType.PERMISSION_UPDATED);
+    return saved;
+  }
+
+  async getSharing(goalId: string, ownerId: string): Promise<SavingsGoalShare> {
+    await this.assertGoalOwner(goalId, ownerId);
+    const share = await this.shareRepository.findOne({ where: { goalId } });
+    if (!share) {
+      throw new NotFoundException('Sharing settings have not been created');
+    }
+    return share;
+  }
+
+  async createShareLink(
+    goalId: string,
+    ownerId: string,
+    expiresAt?: string,
+  ): Promise<{ share: SavingsGoalShare; shareUrl: string }> {
+    await this.assertGoalOwner(goalId, ownerId);
+
+    let share = await this.shareRepository.findOne({ where: { goalId } });
+    if (!share) {
+      share = this.shareRepository.create({
+        goalId,
+        ownerId,
+        visibility: SavingsGoalShareVisibility.UNLISTED,
+      });
+    }
+
+    if (share.visibility === SavingsGoalShareVisibility.PRIVATE) {
+      share.visibility = SavingsGoalShareVisibility.UNLISTED;
+    }
+
+    share.shareToken = await this.generateUniqueToken();
+    share.expiresAt = expiresAt ? new Date(expiresAt) : null;
+    share.revokedAt = null;
+
+    const saved = await this.shareRepository.save(share);
+    await this.recordEvent(saved, SavingsGoalShareEventType.LINK_CREATED);
+    return { share: saved, shareUrl: this.buildShareUrl(saved.shareToken) };
+  }
+
+  async revokeShare(
+    goalId: string,
+    ownerId: string,
+  ): Promise<SavingsGoalShare> {
+    await this.assertGoalOwner(goalId, ownerId);
+    const share = await this.shareRepository.findOne({ where: { goalId } });
+    if (!share) {
+      throw new NotFoundException('Sharing settings have not been created');
+    }
+
+    share.revokedAt = new Date();
+    share.visibility = SavingsGoalShareVisibility.PRIVATE;
+    share.isDirectoryListed = false;
+    const saved = await this.shareRepository.save(share);
+    await this.recordEvent(saved, SavingsGoalShareEventType.REVOKED);
+    return saved;
+  }
+
+  async getSharedGoalByToken(
+    token: string,
+    viewerId?: string,
+  ): Promise<SharedGoalResponse> {
+    const share = await this.shareRepository.findOne({
+      where: { shareToken: token },
+      relations: ['goal', 'owner'],
+    });
+    if (!share) {
+      throw new NotFoundException('Shared goal not found');
+    }
+
+    this.assertShareActive(share);
+    this.assertViewerCanAccess(share, viewerId);
+
+    await this.recordEvent(share, SavingsGoalShareEventType.VIEW, viewerId);
+    return this.mapSharedGoal(share);
+  }
+
+  async getDirectory(
+    page = 1,
+    limit = 20,
+    viewerId?: string,
+  ): Promise<{
+    data: SharedGoalResponse[];
+    page: number;
+    limit: number;
+    total: number;
+  }> {
+    const safePage = Math.max(1, Number(page) || 1);
+    const safeLimit = Math.min(50, Math.max(1, Number(limit) || 20));
+
+    const [shares, total] = await this.shareRepository.findAndCount({
+      where: [
+        {
+          visibility: SavingsGoalShareVisibility.PUBLIC,
+          isDirectoryListed: true,
+          revokedAt: IsNull(),
+          expiresAt: IsNull(),
+        },
+        {
+          visibility: SavingsGoalShareVisibility.PUBLIC,
+          isDirectoryListed: true,
+          revokedAt: IsNull(),
+          expiresAt: MoreThan(new Date()),
+        },
+      ],
+      relations: ['goal', 'owner'],
+      order: { updatedAt: 'DESC' },
+      skip: (safePage - 1) * safeLimit,
+      take: safeLimit,
+    });
+
+    for (const share of shares) {
+      await this.recordEvent(
+        share,
+        SavingsGoalShareEventType.DIRECTORY_VIEW,
+        viewerId,
+      );
+    }
+
+    return {
+      data: await Promise.all(shares.map((share) => this.mapSharedGoal(share))),
+      page: safePage,
+      limit: safeLimit,
+      total,
+    };
+  }
+
+  async getProgressUpdate(
+    goalId: string,
+    viewerId?: string,
+  ): Promise<SharedGoalResponse> {
+    const share = await this.shareRepository.findOne({
+      where: { goalId },
+      relations: ['goal', 'owner'],
+    });
+    if (!share) {
+      throw new NotFoundException('Shared goal not found');
+    }
+
+    this.assertShareActive(share);
+    this.assertViewerCanAccess(share, viewerId);
+    if (!share.allowProgressUpdates || !share.showProgress) {
+      throw new ForbiddenException(
+        'Progress updates are private for this goal',
+      );
+    }
+
+    await this.recordEvent(
+      share,
+      SavingsGoalShareEventType.PROGRESS_UPDATE,
+      viewerId,
+    );
+    return this.mapSharedGoal(share);
+  }
+
+  async createSocialShare(
+    goalId: string,
+    ownerId: string,
+    dto: SocialShareDto,
+  ): Promise<{
+    platform: string;
+    shareUrl: string;
+    intentUrl: string;
+    message: string;
+  }> {
+    const share = await this.getSharing(goalId, ownerId);
+    this.assertShareActive(share);
+    if (!share.allowSocialSharing) {
+      throw new ForbiddenException('Social sharing is disabled for this goal');
+    }
+    if (!share.shareToken) {
+      share.shareToken = await this.generateUniqueToken();
+      await this.shareRepository.save(share);
+    }
+
+    const shareUrl = this.buildShareUrl(share.shareToken);
+    const message =
+      dto.message ?? `Follow my Nestera savings goal progress: ${shareUrl}`;
+    await this.recordEvent(
+      share,
+      SavingsGoalShareEventType.SOCIAL_SHARE,
+      ownerId,
+      {
+        platform: dto.platform,
+        message,
+      },
+    );
+
+    return {
+      platform: dto.platform,
+      shareUrl,
+      intentUrl: this.buildSocialIntentUrl(dto.platform, shareUrl, message),
+      message,
+    };
+  }
+
+  async getAnalytics(
+    goalId: string,
+    ownerId: string,
+  ): Promise<{
+    goalId: string;
+    totalViews: number;
+    directoryViews: number;
+    socialShares: number;
+    progressUpdates: number;
+    uniqueViewers: number;
+    byPlatform: Record<string, number>;
+  }> {
+    const share = await this.getSharing(goalId, ownerId);
+    const events = await this.eventRepository.find({
+      where: { shareId: share.id },
+    });
+
+    const byPlatform: Record<string, number> = {};
+    for (const event of events) {
+      if (event.platform) {
+        byPlatform[event.platform] = (byPlatform[event.platform] ?? 0) + 1;
+      }
+    }
+
+    return {
+      goalId,
+      totalViews: events.filter(
+        (event) => event.eventType === SavingsGoalShareEventType.VIEW,
+      ).length,
+      directoryViews: events.filter(
+        (event) => event.eventType === SavingsGoalShareEventType.DIRECTORY_VIEW,
+      ).length,
+      socialShares: events.filter(
+        (event) => event.eventType === SavingsGoalShareEventType.SOCIAL_SHARE,
+      ).length,
+      progressUpdates: events.filter(
+        (event) =>
+          event.eventType === SavingsGoalShareEventType.PROGRESS_UPDATE,
+      ).length,
+      uniqueViewers: new Set(
+        events.map((event) => event.viewerId).filter(Boolean),
+      ).size,
+      byPlatform,
+    };
+  }
+
+  private async assertGoalOwner(
+    goalId: string,
+    ownerId: string,
+  ): Promise<SavingsGoal> {
+    const goal = await this.goalRepository.findOne({
+      where: { id: goalId, userId: ownerId },
+    });
+    if (!goal) {
+      throw new NotFoundException(
+        `Savings goal ${goalId} not found or does not belong to user`,
+      );
+    }
+    return goal;
+  }
+
+  private assertShareActive(share: SavingsGoalShare): void {
+    if (share.revokedAt) {
+      throw new ForbiddenException('This share has been revoked');
+    }
+    if (share.expiresAt && share.expiresAt.getTime() <= Date.now()) {
+      throw new ForbiddenException('This share link has expired');
+    }
+    if (share.visibility === SavingsGoalShareVisibility.PRIVATE) {
+      throw new ForbiddenException('This goal is private');
+    }
+  }
+
+  private assertViewerCanAccess(
+    share: SavingsGoalShare,
+    viewerId?: string,
+  ): void {
+    if (
+      share.visibility === SavingsGoalShareVisibility.PUBLIC ||
+      share.visibility === SavingsGoalShareVisibility.UNLISTED
+    ) {
+      return;
+    }
+    if (share.ownerId === viewerId) {
+      return;
+    }
+    if (
+      share.visibility === SavingsGoalShareVisibility.FRIENDS &&
+      viewerId &&
+      (share.allowedUserIds ?? []).includes(viewerId)
+    ) {
+      return;
+    }
+    throw new ForbiddenException(
+      'You do not have permission to view this goal',
+    );
+  }
+
+  private async mapSharedGoal(
+    share: SavingsGoalShare,
+  ): Promise<SharedGoalResponse> {
+    const progress = await this.findGoalProgress(share.goal);
+    return {
+      goal: {
+        id: share.goal.id,
+        goalName: share.goal.goalName,
+        targetDate: share.goal.targetDate,
+        status: share.goal.status,
+        metadata: share.goal.metadata,
+        ...(share.showTargetAmount
+          ? { targetAmount: Number(share.goal.targetAmount) }
+          : {}),
+        ...(share.showProgress && progress
+          ? {
+              currentBalance: progress.currentBalance,
+              percentageComplete: progress.percentageComplete,
+              projectedBalance: progress.projectedBalance,
+              isOffTrack: progress.isOffTrack,
+              projectionGap: progress.projectionGap,
+            }
+          : {}),
+      },
+      owner: {
+        id: share.ownerId,
+        name: share.showOwnerName ? share.owner?.name : null,
+      },
+      share,
+    };
+  }
+
+  private async findGoalProgress(
+    goal: SavingsGoal,
+  ): Promise<SavingsGoalProgress | undefined> {
+    const goals = await this.savingsService.findMyGoals(goal.userId);
+    return goals.find((item) => item.id === goal.id);
+  }
+
+  private async recordEvent(
+    share: SavingsGoalShare,
+    eventType: SavingsGoalShareEventType,
+    viewerId?: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    await this.eventRepository.save(
+      this.eventRepository.create({
+        shareId: share.id,
+        goalId: share.goalId,
+        viewerId: viewerId ?? null,
+        eventType,
+        platform:
+          typeof metadata?.platform === 'string' ? metadata.platform : null,
+        metadata: metadata ?? null,
+      }),
+    );
+  }
+
+  private async generateUniqueToken(): Promise<string> {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const token = randomBytes(24).toString('base64url');
+      const existing = await this.shareRepository.findOne({
+        where: { shareToken: token },
+      });
+      if (!existing) {
+        return token;
+      }
+    }
+    throw new BadRequestException('Unable to generate a share token');
+  }
+
+  private buildShareUrl(token: string | null): string {
+    const baseUrl =
+      this.configService.get<string>('PUBLIC_APP_URL') ??
+      this.configService.get<string>('APP_URL') ??
+      'http://localhost:3000';
+    return `${baseUrl.replace(/\/$/, '')}/goals/shared/${token}`;
+  }
+
+  private buildSocialIntentUrl(
+    platform: SocialShareDto['platform'],
+    shareUrl: string,
+    message: string,
+  ): string {
+    const encodedUrl = encodeURIComponent(shareUrl);
+    const encodedMessage = encodeURIComponent(message);
+    switch (platform) {
+      case 'x':
+        return `https://twitter.com/intent/tweet?text=${encodedMessage}&url=${encodedUrl}`;
+      case 'facebook':
+        return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
+      case 'linkedin':
+        return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
+      case 'whatsapp':
+        return `https://wa.me/?text=${encodedMessage}%20${encodedUrl}`;
+      case 'copy':
+      default:
+        return shareUrl;
+    }
+  }
+}

--- a/backend/src/modules/savings/savings.module.ts
+++ b/backend/src/modules/savings/savings.module.ts
@@ -28,6 +28,10 @@ import { GroupSavingsService } from './group-savings.service';
 import { GroupSavingsController } from './group-savings.controller';
 import { AutoDepositSchedule } from './entities/auto-deposit-schedule.entity';
 import { AutoDepositService } from './services/auto-deposit.service';
+import { SavingsGoalShare } from './entities/savings-goal-share.entity';
+import { SavingsGoalShareEvent } from './entities/savings-goal-share-event.entity';
+import { SavingsGoalSharingService } from './savings-goal-sharing.service';
+import { SavingsGoalSharingController } from './savings-goal-sharing.controller';
 
 @Module({
   imports: [
@@ -49,9 +53,16 @@ import { AutoDepositService } from './services/auto-deposit.service';
       SavingsGroupMember,
       SavingsGroupActivity,
       AutoDepositSchedule,
+      SavingsGoalShare,
+      SavingsGoalShareEvent,
     ]),
   ],
-  controllers: [SavingsController, WaitlistController, GroupSavingsController],
+  controllers: [
+    SavingsController,
+    WaitlistController,
+    GroupSavingsController,
+    SavingsGoalSharingController,
+  ],
   providers: [
     SavingsService,
     PredictiveEvaluatorService,
@@ -61,7 +72,13 @@ import { AutoDepositService } from './services/auto-deposit.service';
     ExperimentsService,
     GroupSavingsService,
     AutoDepositService,
+    SavingsGoalSharingService,
   ],
-  exports: [SavingsService, WaitlistService, ExperimentsService],
+  exports: [
+    SavingsService,
+    WaitlistService,
+    ExperimentsService,
+    SavingsGoalSharingService,
+  ],
 })
 export class SavingsModule {}


### PR DESCRIPTION
## Summary

This PR adds backend support for Savings Goal Sharing, allowing users to share savings goals publicly, privately with selected users, or through unlisted share links while preserving privacy controls around goal progress, target amount, owner identity, social sharing, and analytics.

## What Changed

✅ Added a savings goal sharing permission system  
✅ Added shareable link generation using secure share tokens  
✅ Added public goal directory support for publicly listed goals  
✅ Added privacy controls for progress, target amount, owner name, social sharing, and progress updates  
✅ Added friend-restricted sharing via allowed user IDs  
✅ Added social media share intent generation for X, Facebook, LinkedIn, WhatsApp, and copy-link flows  
✅ Added sharing analytics event tracking for views, directory views, social shares, and progress updates  
✅ Added database migration for sharing and analytics tables  
✅ Added focused unit tests for sharing behavior and access control  
✅ Wired the new sharing service/controller into the existing Savings module

## New API Capabilities

- `PATCH /savings/goals/:id/share`  
  Create or update sharing permissions for a savings goal.

- `GET /savings/goals/:id/share`  
  Fetch sharing settings for the authenticated goal owner.

- `POST /savings/goals/:id/share/link`  
  Generate a shareable link for a goal.

- `DELETE /savings/goals/:id/share`  
  Revoke sharing for a goal.

- `GET /savings/share/:token`  
  Resolve a shared goal by token.

- `GET /savings/public-goals`  
  List publicly shared and directory-listed savings goals.

- `GET /savings/goals/:id/share/progress`  
  Fetch progress updates for a shared goal when permitted.

- `POST /savings/goals/:id/share/social`  
  Generate a social share intent URL.

- `GET /savings/goals/:id/share/analytics`  
  Fetch sharing analytics for the goal owner.

## Database Changes

Added migration:

- `1800200000000-CreateSavingsGoalSharingTables.ts`

New tables:

- `savings_goal_shares`
- `savings_goal_share_events`

These tables store goal sharing permissions, share tokens, privacy settings, visibility controls, friend allow-lists, and analytics events.

## Privacy & Access Control

This implementation supports:

✅ Private goals  
✅ Public goals  
✅ Unlisted share links  
✅ Friend-restricted sharing  
✅ Revoked shares  
✅ Expiring share links  
✅ Optional visibility for progress  
✅ Optional visibility for target amount  
✅ Optional visibility for owner name  
✅ Optional social sharing  
✅ Optional progress update access

## Testing

Added focused unit coverage for:

✅ Creating public sharing settings  
✅ Blocking directory listing for non-public shares  
✅ Creating shareable links  
✅ Returning redacted shared goal responses  
✅ Denying unauthorized friend-only access  
✅ Generating social share intents  
✅ Aggregating sharing analytics

Issue:
close #945 

## Notes

A targeted TypeScript compile for the new sharing files passed.

Full backend build/test execution was blocked by pre-existing unrelated project issues:
- Existing syntax issue in `backend/src/modules/webhooks/dto/create-webhook.dto.ts`
- Local Jest/Nest dependency resolution issues during verification