### PR TITLE
feat: add comprehensive user preference system for notifications, pri…

### DIFF
--- a/backend/src/migrations/1800300000000-AddUserPreferenceCategories.ts
+++ b/backend/src/migrations/1800300000000-AddUserPreferenceCategories.ts
@@ -1,0 +1,122 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserPreferenceCategories1800300000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'preferred_contact_channel_enum') THEN
+          CREATE TYPE "preferred_contact_channel_enum" AS ENUM ('EMAIL', 'SMS', 'PUSH', 'IN_APP');
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'profile_visibility_enum') THEN
+          CREATE TYPE "profile_visibility_enum" AS ENUM ('PUBLIC', 'PRIVATE', 'FRIENDS_ONLY');
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'theme_preference_enum') THEN
+          CREATE TYPE "theme_preference_enum" AS ENUM ('LIGHT', 'DARK', 'SYSTEM');
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'date_format_preference_enum') THEN
+          CREATE TYPE "date_format_preference_enum" AS ENUM ('MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY-MM-DD');
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "preferredContactChannel" "preferred_contact_channel_enum" NOT NULL DEFAULT 'EMAIL'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "newsletterSubscribed" BOOLEAN NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "profileVisibility" "profile_visibility_enum" NOT NULL DEFAULT 'PRIVATE'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "dataSharingEnabled" BOOLEAN NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "personalizedAds" BOOLEAN NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "locationSharing" BOOLEAN NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "theme" "theme_preference_enum" NOT NULL DEFAULT 'SYSTEM'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "language" VARCHAR(10) NOT NULL DEFAULT 'en'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "currency" VARCHAR(3) NOT NULL DEFAULT 'USD'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "dateFormat" "date_format_preference_enum" NOT NULL DEFAULT 'MM/DD/YYYY'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "compactLayout" BOOLEAN NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "displayBalancesInFiat" BOOLEAN NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "displayBalancesInFiat"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "compactLayout"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "dateFormat"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "currency"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "language"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "theme"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "locationSharing"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "personalizedAds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "dataSharingEnabled"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "profileVisibility"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "newsletterSubscribed"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_preferences" DROP COLUMN IF EXISTS "preferredContactChannel"`,
+    );
+
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "date_format_preference_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE IF EXISTS "theme_preference_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "profile_visibility_enum"`);
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "preferred_contact_channel_enum"`,
+    );
+  }
+}

--- a/backend/src/modules/notifications/dto/update-notification-preference.dto.ts
+++ b/backend/src/modules/notifications/dto/update-notification-preference.dto.ts
@@ -4,12 +4,17 @@ import {
   IsEnum,
   IsString,
   Matches,
-  ValidateIf,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { DigestFrequency } from '../entities/notification-preference.entity';
+import {
+  DigestFrequency,
+  ProfileVisibility,
+  ThemePreference,
+  DateFormatPreference,
+  PreferredContactChannel,
+} from '../entities/notification-preference.entity';
 
-export class UpdateNotificationPreferenceDto {
+export class UpdateUserPreferenceDto {
   // Channel preferences
   @ApiPropertyOptional()
   @IsOptional()
@@ -30,6 +35,11 @@ export class UpdateNotificationPreferenceDto {
   @IsOptional()
   @IsBoolean()
   smsNotifications?: boolean;
+
+  @ApiPropertyOptional({ enum: PreferredContactChannel })
+  @IsOptional()
+  @IsEnum(PreferredContactChannel)
+  preferredContactChannel?: PreferredContactChannel;
 
   // Notification type preferences
   @ApiPropertyOptional()
@@ -57,7 +67,6 @@ export class UpdateNotificationPreferenceDto {
   @IsBoolean()
   marketingNotifications?: boolean;
 
-  // Legacy
   @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
@@ -77,6 +86,69 @@ export class UpdateNotificationPreferenceDto {
   @IsOptional()
   @IsBoolean()
   milestoneNotifications?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  newsletterSubscribed?: boolean;
+
+  // Privacy preferences
+  @ApiPropertyOptional({ enum: ProfileVisibility })
+  @IsOptional()
+  @IsEnum(ProfileVisibility)
+  profileVisibility?: ProfileVisibility;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  dataSharingEnabled?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  personalizedAds?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  locationSharing?: boolean;
+
+  // Display preferences
+  @ApiPropertyOptional({ enum: ThemePreference })
+  @IsOptional()
+  @IsEnum(ThemePreference)
+  theme?: ThemePreference;
+
+  @ApiPropertyOptional({ example: 'en' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z]{2}(-[A-Z]{2})?$/, {
+    message: 'language must be a valid locale code',
+  })
+  language?: string;
+
+  @ApiPropertyOptional({ example: 'USD' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Z]{3}$/, {
+    message: 'currency must be a 3-letter ISO code',
+  })
+  currency?: string;
+
+  @ApiPropertyOptional({ enum: DateFormatPreference })
+  @IsOptional()
+  @IsEnum(DateFormatPreference)
+  dateFormat?: DateFormatPreference;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  compactLayout?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  displayBalancesInFiat?: boolean;
 
   // Quiet hours
   @ApiPropertyOptional()

--- a/backend/src/modules/notifications/entities/notification-preference.entity.ts
+++ b/backend/src/modules/notifications/entities/notification-preference.entity.ts
@@ -13,16 +13,41 @@ export enum DigestFrequency {
   WEEKLY = 'weekly',
 }
 
+export enum ProfileVisibility {
+  PUBLIC = 'PUBLIC',
+  PRIVATE = 'PRIVATE',
+  FRIENDS_ONLY = 'FRIENDS_ONLY',
+}
+
+export enum ThemePreference {
+  LIGHT = 'LIGHT',
+  DARK = 'DARK',
+  SYSTEM = 'SYSTEM',
+}
+
+export enum DateFormatPreference {
+  MM_DD_YYYY = 'MM/DD/YYYY',
+  DD_MM_YYYY = 'DD/MM/YYYY',
+  YYYY_MM_DD = 'YYYY-MM-DD',
+}
+
+export enum PreferredContactChannel {
+  EMAIL = 'EMAIL',
+  SMS = 'SMS',
+  PUSH = 'PUSH',
+  IN_APP = 'IN_APP',
+}
+
 @Entity('notification_preferences')
 @Unique(['userId'])
-export class NotificationPreference {
+export class UserPreference {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column('uuid')
   userId: string;
 
-  // ── Channel preferences ──────────────────────────────────────────────────
+  // ── Communication channel preferences ────────────────────────────────────
   @Column({ type: 'boolean', default: true })
   emailNotifications: boolean;
 
@@ -34,6 +59,13 @@ export class NotificationPreference {
 
   @Column({ type: 'boolean', default: false })
   smsNotifications: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: PreferredContactChannel,
+    default: PreferredContactChannel.EMAIL,
+  })
+  preferredContactChannel: PreferredContactChannel;
 
   // ── Notification type preferences ────────────────────────────────────────
   @Column({ type: 'boolean', default: true })
@@ -51,7 +83,6 @@ export class NotificationPreference {
   @Column({ type: 'boolean', default: false })
   marketingNotifications: boolean;
 
-  // Legacy columns kept for backward compatibility
   @Column({ type: 'boolean', default: true })
   sweepNotifications: boolean;
 
@@ -63,6 +94,53 @@ export class NotificationPreference {
 
   @Column({ type: 'boolean', default: true })
   milestoneNotifications: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  newsletterSubscribed: boolean;
+
+  // ── Privacy preferences ──────────────────────────────────────────────────
+  @Column({
+    type: 'enum',
+    enum: ProfileVisibility,
+    default: ProfileVisibility.PRIVATE,
+  })
+  profileVisibility: ProfileVisibility;
+
+  @Column({ type: 'boolean', default: false })
+  dataSharingEnabled: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  personalizedAds: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  locationSharing: boolean;
+
+  // ── Display preferences ──────────────────────────────────────────────────
+  @Column({
+    type: 'enum',
+    enum: ThemePreference,
+    default: ThemePreference.SYSTEM,
+  })
+  theme: ThemePreference;
+
+  @Column({ type: 'varchar', length: 10, default: 'en' })
+  language: string;
+
+  @Column({ type: 'varchar', length: 3, default: 'USD' })
+  currency: string;
+
+  @Column({
+    type: 'enum',
+    enum: DateFormatPreference,
+    default: DateFormatPreference.MM_DD_YYYY,
+  })
+  dateFormat: DateFormatPreference;
+
+  @Column({ type: 'boolean', default: false })
+  compactLayout: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  displayBalancesInFiat: boolean;
 
   // ── Quiet hours ──────────────────────────────────────────────────────────
   @Column({ type: 'boolean', default: false })

--- a/backend/src/modules/notifications/governance-notification.scheduler.spec.ts
+++ b/backend/src/modules/notifications/governance-notification.scheduler.spec.ts
@@ -7,7 +7,7 @@ import { StellarService } from '../blockchain/stellar.service';
 import { PendingNotification } from './entities/pending-notification.entity';
 import { NotificationType } from './entities/notification.entity';
 import {
-  NotificationPreference,
+  UserPreference,
   DigestFrequency,
 } from './entities/notification-preference.entity';
 import { User } from '../user/entities/user.entity';
@@ -57,7 +57,7 @@ describe('GovernanceNotificationScheduler', () => {
           useValue: pendingRepo,
         },
         {
-          provide: getRepositoryToken(NotificationPreference),
+          provide: getRepositoryToken(UserPreference),
           useValue: preferenceRepo,
         },
         { provide: getRepositoryToken(User), useValue: userRepo },

--- a/backend/src/modules/notifications/governance-notification.scheduler.ts
+++ b/backend/src/modules/notifications/governance-notification.scheduler.ts
@@ -6,7 +6,7 @@ import { NotificationsService } from './notifications.service';
 import { NotificationType } from './entities/notification.entity';
 import { PendingNotification } from './entities/pending-notification.entity';
 import {
-  NotificationPreference,
+  UserPreference,
   DigestFrequency,
 } from './entities/notification-preference.entity';
 import { User } from '../user/entities/user.entity';
@@ -29,8 +29,8 @@ export class GovernanceNotificationScheduler {
     private readonly stellarService: StellarService,
     @InjectRepository(PendingNotification)
     private readonly pendingRepo: Repository<PendingNotification>,
-    @InjectRepository(NotificationPreference)
-    private readonly preferenceRepo: Repository<NotificationPreference>,
+    @InjectRepository(UserPreference)
+    private readonly preferenceRepo: Repository<UserPreference>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     @InjectRepository(GovernanceProposal)

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -1,7 +1,9 @@
 import {
   Controller,
   Get,
+  Post,
   Patch,
+  Delete,
   Body,
   Param,
   Query,
@@ -13,7 +15,7 @@ import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { NotificationsService } from './notifications.service';
-import { UpdateNotificationPreferenceDto } from './dto/update-notification-preference.dto';
+import { UpdateUserPreferenceDto } from './dto/update-notification-preference.dto';
 import { User } from '../user/entities/user.entity';
 
 @ApiTags('notifications')
@@ -65,18 +67,34 @@ export class NotificationsController {
     return await this.notificationsService.getOrCreatePreferences(user.id);
   }
 
+  @Post('preferences')
+  @ApiOperation({ summary: 'Create or restore user preference settings' })
+  async createPreferences(@CurrentUser() user: User) {
+    return await this.notificationsService.createPreferences(user.id);
+  }
+
   @Patch('preferences')
   @ApiOperation({
     summary:
-      'Update notification preferences (channels, types, quiet hours, digest)',
+      'Update user preferences (notifications, privacy, display, channels, quiet hours, digest)',
   })
   async updatePreferences(
     @CurrentUser() user: User,
-    @Body() updateDto: UpdateNotificationPreferenceDto,
+    @Body() updateDto: UpdateUserPreferenceDto,
   ) {
     return await this.notificationsService.updatePreferences(
       user.id,
       updateDto,
     );
+  }
+
+  @Delete('preferences')
+  @ApiOperation({ summary: 'Reset user preferences to defaults' })
+  async deletePreferences(@CurrentUser() user: User) {
+    await this.notificationsService.deletePreferences(user.id);
+    return {
+      message:
+        'Preferences deleted. Defaults will be recreated on next retrieval.',
+    };
   }
 }

--- a/backend/src/modules/notifications/notifications.module.ts
+++ b/backend/src/modules/notifications/notifications.module.ts
@@ -4,7 +4,7 @@ import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
 import { UserNotificationsController } from './user-notifications.controller';
 import { Notification } from './entities/notification.entity';
-import { NotificationPreference } from './entities/notification-preference.entity';
+import { UserPreference } from './entities/notification-preference.entity';
 import { PendingNotification } from './entities/pending-notification.entity';
 import { WaitlistEntry } from '../savings/entities/waitlist-entry.entity';
 import { WaitlistEvent } from '../savings/entities/waitlist-event.entity';
@@ -22,7 +22,7 @@ import { SavingsModule } from '../savings/savings.module';
   imports: [
     TypeOrmModule.forFeature([
       Notification,
-      NotificationPreference,
+      UserPreference,
       PendingNotification,
       User,
       WaitlistEntry,

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification, NotificationType } from './entities/notification.entity';
 import {
-  NotificationPreference,
+  UserPreference,
   DigestFrequency,
 } from './entities/notification-preference.entity';
 import { PendingNotification } from './entities/pending-notification.entity';
@@ -57,8 +57,8 @@ export class NotificationsService {
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepository: Repository<Notification>,
-    @InjectRepository(NotificationPreference)
-    private readonly preferenceRepository: Repository<NotificationPreference>,
+    @InjectRepository(UserPreference)
+    private readonly preferenceRepository: Repository<UserPreference>,
     @InjectRepository(PendingNotification)
     private readonly pendingRepository: Repository<PendingNotification>,
     @InjectRepository(Delegation)
@@ -602,9 +602,7 @@ export class NotificationsService {
   /**
    * Get or create notification preferences for user
    */
-  async getOrCreatePreferences(
-    userId: string,
-  ): Promise<NotificationPreference> {
+  async getOrCreatePreferences(userId: string): Promise<UserPreference> {
     let preferences = await this.preferenceRepository.findOne({
       where: { userId },
     });
@@ -618,12 +616,26 @@ export class NotificationsService {
   }
 
   /**
+   * Create default preferences for a user
+   */
+  async createPreferences(userId: string): Promise<UserPreference> {
+    return this.getOrCreatePreferences(userId);
+  }
+
+  /**
+   * Delete preference record for a user, falling back to defaults.
+   */
+  async deletePreferences(userId: string): Promise<void> {
+    await this.preferenceRepository.delete({ userId });
+  }
+
+  /**
    * Update notification preferences
    */
   async updatePreferences(
     userId: string,
-    updates: Partial<NotificationPreference>,
-  ): Promise<NotificationPreference> {
+    updates: Partial<UserPreference>,
+  ): Promise<UserPreference> {
     let preferences = await this.getOrCreatePreferences(userId);
 
     Object.assign(preferences, updates);

--- a/backend/src/modules/notifications/user-notifications.controller.ts
+++ b/backend/src/modules/notifications/user-notifications.controller.ts
@@ -1,9 +1,17 @@
-import { Controller, Get, Patch, Body, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { NotificationsService } from './notifications.service';
-import { UpdateNotificationPreferenceDto } from './dto/update-notification-preference.dto';
+import { UpdateUserPreferenceDto } from './dto/update-notification-preference.dto';
 import { User } from '../user/entities/user.entity';
 
 @ApiTags('users')
@@ -19,15 +27,27 @@ export class UserNotificationsController {
     return this.notificationsService.getOrCreatePreferences(user.id);
   }
 
+  @Post('preferences')
+  @ApiOperation({ summary: 'Create or restore user preference settings' })
+  createPreferences(@CurrentUser() user: User) {
+    return this.notificationsService.createPreferences(user.id);
+  }
+
   @Patch('preferences')
   @ApiOperation({
     summary:
-      'Update notification preferences (channels, types, quiet hours, digest frequency)',
+      'Update user preferences (notifications, privacy, display, channels, quiet hours, digest frequency)',
   })
   updatePreferences(
     @CurrentUser() user: User,
-    @Body() dto: UpdateNotificationPreferenceDto,
+    @Body() dto: UpdateUserPreferenceDto,
   ) {
     return this.notificationsService.updatePreferences(user.id, dto);
+  }
+
+  @Delete('preferences')
+  @ApiOperation({ summary: 'Reset user preferences to defaults' })
+  deletePreferences(@CurrentUser() user: User) {
+    return this.notificationsService.deletePreferences(user.id);
   }
 }


### PR DESCRIPTION
Implemented a comprehensive user preferences system for the backend:

Added a centralized [UserPreference](https://scaling-parakeet-6v94gvpwp79rc5rrx.github.dev/) schema covering notification channels, privacy settings, display preferences, and communication channels
Extended notification preference DTO/validation to support new categories
Added CRUD endpoints for retrieving, creating/restoring, updating, and resetting user preferences
Introduced default preferences and schema-level validation rules
Added a TypeORM migration to add new preference columns and enums without breaking existing data
This enables users to manage notifications, privacy, display, and communication settings in a single preference model.
 closes #941