### PR TITLE
[1016] Add Referral Fraud Detection Heuristics

### DIFF
--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -1,32 +1,30 @@
 import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { PiiEncryptionService } from './services/pii-encryption.service';
 import { RateLimitMonitorService } from './services/rate-limit-monitor.service';
 import { SecretsConfigService } from './services/secrets-config.service';
-
-@Global()
-@Module({
-  providers: [
-    RateLimitMonitorService,
-    PiiEncryptionService,
-    SecretsConfigService,
 import { IdempotencyService } from './services/idempotency.service';
 import { IdempotencyCleanupService } from './services/idempotency-cleanup.service';
 import { LogSanitizerService } from './services/log-sanitizer.service';
 import { CompressionMetricsService } from './services/compression-metrics.service';
 import { CompressionMetricsMiddleware } from './middleware/compression.middleware';
+import { AuditLogService } from './services/audit-log.service';
+import { AuditLog } from './entities/audit-log.entity';
 import { CacheModule } from '../modules/cache/cache.module';
 
 @Global()
 @Module({
-  imports: [CacheModule],
+  imports: [CacheModule, TypeOrmModule.forFeature([AuditLog])],
   providers: [
     RateLimitMonitorService,
     PiiEncryptionService,
+    SecretsConfigService,
     IdempotencyService,
     IdempotencyCleanupService,
     LogSanitizerService,
     CompressionMetricsService,
     CompressionMetricsMiddleware,
+    AuditLogService,
   ],
   exports: [
     RateLimitMonitorService,
@@ -35,6 +33,7 @@ import { CacheModule } from '../modules/cache/cache.module';
     IdempotencyService,
     LogSanitizerService,
     CompressionMetricsService,
+    AuditLogService,
   ],
 })
 export class CommonModule {}

--- a/backend/src/migrations/1800500000002-AddReferralFraudDetection.ts
+++ b/backend/src/migrations/1800500000002-AddReferralFraudDetection.ts
@@ -1,0 +1,111 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableColumn,
+  TableIndex,
+} from 'typeorm';
+
+export class AddReferralFraudDetection1800500000002 implements MigrationInterface {
+  name = 'AddReferralFraudDetection1800500000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "referrals_status_enum" ADD VALUE IF NOT EXISTS 'quarantined'`,
+    );
+
+    const referralsTable = await queryRunner.getTable('referrals');
+    if (referralsTable && !referralsTable.findColumnByName('fraud_reasons')) {
+      await queryRunner.addColumns('referrals', [
+        new TableColumn({
+          name: 'fraud_reasons',
+          type: 'jsonb',
+          isNullable: true,
+        }),
+        new TableColumn({
+          name: 'requires_manual_review',
+          type: 'boolean',
+          default: false,
+        }),
+        new TableColumn({
+          name: 'quarantined_at',
+          type: 'timestamp',
+          isNullable: true,
+        }),
+      ]);
+    }
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'referral_fraud_audits',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'referral_id',
+            type: 'uuid',
+          },
+          {
+            name: 'referrer_id',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'referee_id',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'reasons',
+            type: 'jsonb',
+          },
+          {
+            name: 'decision_metadata',
+            type: 'jsonb',
+          },
+          {
+            name: 'rationale',
+            type: 'text',
+          },
+          {
+            name: 'action',
+            type: 'varchar',
+            length: '32',
+          },
+          {
+            name: 'actor',
+            type: 'varchar',
+            length: '64',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'referral_fraud_audits',
+      new TableIndex({
+        name: 'idx_referral_fraud_audits_referral_id',
+        columnNames: ['referral_id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('referral_fraud_audits');
+    await queryRunner.dropColumn('referrals', 'quarantined_at');
+    await queryRunner.dropColumn('referrals', 'requires_manual_review');
+    await queryRunner.dropColumn('referrals', 'fraud_reasons');
+  }
+}

--- a/backend/src/modules/referrals/entities/referral-fraud-audit.entity.ts
+++ b/backend/src/modules/referrals/entities/referral-fraud-audit.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { ReferralFraudReason } from '../referral-fraud.types';
+
+@Entity('referral_fraud_audits')
+@Index(['referralId'])
+@Index(['createdAt'])
+export class ReferralFraudAudit {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  referralId: string;
+
+  @Column('uuid', { nullable: true })
+  referrerId: string | null;
+
+  @Column('uuid', { nullable: true })
+  refereeId: string | null;
+
+  @Column({ type: 'jsonb' })
+  reasons: ReferralFraudReason[];
+
+  @Column({ type: 'jsonb' })
+  decisionMetadata: Record<string, unknown>;
+
+  @Column({ type: 'text' })
+  rationale: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  action: 'quarantine' | 'flag' | 'block_reward';
+
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  actor: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/modules/referrals/entities/referral.entity.ts
+++ b/backend/src/modules/referrals/entities/referral.entity.ts
@@ -15,6 +15,7 @@ export enum ReferralStatus {
   COMPLETED = 'completed',
   REWARDED = 'rewarded',
   EXPIRED = 'expired',
+  QUARANTINED = 'quarantined',
   FRAUDULENT = 'fraudulent',
 }
 
@@ -63,6 +64,15 @@ export class Referral {
 
   @Column({ type: 'jsonb', nullable: true })
   metadata: Record<string, any> | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  fraudReasons: string[] | null;
+
+  @Column({ type: 'boolean', default: false })
+  requiresManualReview: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  quarantinedAt: Date | null;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/modules/referrals/referral-fraud-detection.service.spec.ts
+++ b/backend/src/modules/referrals/referral-fraud-detection.service.spec.ts
@@ -1,0 +1,151 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ReferralFraudDetectionService } from './referral-fraud-detection.service';
+import { Referral, ReferralStatus } from './entities/referral.entity';
+import { ReferralFraudAudit } from './entities/referral-fraud-audit.entity';
+import {
+  Transaction,
+  TxType,
+} from '../transactions/entities/transaction.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import { ReferralFraudReason } from './referral-fraud.types';
+
+describe('ReferralFraudDetectionService', () => {
+  let service: ReferralFraudDetectionService;
+  let referralRepo: any;
+  let fraudAuditRepo: any;
+  let transactionRepo: any;
+
+  const referral: Referral = {
+    id: 'ref-1',
+    referrerId: 'user-1',
+    refereeId: 'user-2',
+    referralCode: 'CODE1234',
+    status: ReferralStatus.PENDING,
+    rewardAmount: null,
+    campaignId: null,
+    metadata: null,
+    fraudReasons: null,
+    requiresManualReview: false,
+    quarantinedAt: null,
+    createdAt: new Date(),
+    completedAt: null,
+    rewardedAt: null,
+    referrer: null as any,
+    referee: null,
+    campaign: null,
+  };
+
+  beforeEach(async () => {
+    referralRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      find: jest.fn().mockResolvedValue([]),
+      save: jest.fn().mockImplementation((val) => Promise.resolve(val)),
+      create: jest.fn().mockImplementation((val) => val),
+    };
+    fraudAuditRepo = {
+      save: jest.fn().mockImplementation((val) => Promise.resolve(val)),
+      create: jest.fn().mockImplementation((val) => val),
+    };
+    transactionRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralFraudDetectionService,
+        { provide: getRepositoryToken(Referral), useValue: referralRepo },
+        {
+          provide: getRepositoryToken(ReferralFraudAudit),
+          useValue: fraudAuditRepo,
+        },
+        { provide: getRepositoryToken(Transaction), useValue: transactionRepo },
+        { provide: AuditLogService, useValue: { log: jest.fn() } },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(
+              (_key: string, defaultValue?: unknown) => defaultValue,
+            ),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ReferralFraudDetectionService);
+  });
+
+  it('detects self-referrals', async () => {
+    const result = await service.evaluateReferral({
+      ...referral,
+      refereeId: referral.referrerId,
+    });
+
+    expect(result.isSuspicious).toBe(true);
+    expect(result.reasons).toContain(ReferralFraudReason.SELF_REFERRAL);
+  });
+
+  it('detects similar metadata attempts', async () => {
+    const context = { ipAddress: '127.0.0.1', userAgent: 'jest' };
+    const fingerprint = service.buildMetadataFingerprint(context);
+
+    referralRepo.find.mockResolvedValue([
+      {
+        ...referral,
+        id: 'ref-old',
+        metadata: { fingerprint },
+      },
+      {
+        ...referral,
+        id: 'ref-old-2',
+        metadata: { fingerprint },
+      },
+    ]);
+
+    const result = await service.evaluateReferral(referral, context);
+    expect(result.reasons).toContain(ReferralFraudReason.SIMILAR_METADATA);
+  });
+
+  it('enforces referral creation rate limits', () => {
+    for (let i = 0; i < 20; i++) {
+      service.enforceCreationRateLimit('user-1');
+    }
+
+    expect(() => service.enforceCreationRateLimit('user-1')).toThrow(
+      HttpException,
+    );
+  });
+
+  it('quarantines suspicious referrals and writes audit trail', async () => {
+    const evaluation = {
+      isSuspicious: true,
+      reasons: [ReferralFraudReason.EXCESSIVE_CREATION],
+      metadata: { count: 11 },
+      shouldQuarantine: true,
+    };
+
+    const saved = await service.quarantineReferral(referral, evaluation);
+
+    expect(saved.status).toBe(ReferralStatus.QUARANTINED);
+    expect(saved.requiresManualReview).toBe(true);
+    expect(fraudAuditRepo.save).toHaveBeenCalled();
+  });
+
+  it('detects suspicious withdrawal patterns', async () => {
+    transactionRepo.find.mockResolvedValue([
+      {
+        type: TxType.DEPOSIT,
+        createdAt: new Date('2026-01-01T10:00:00Z'),
+      },
+      {
+        type: TxType.WITHDRAW,
+        createdAt: new Date('2026-01-01T10:15:00Z'),
+      },
+    ]);
+
+    const result = await service.evaluateReferral(referral);
+    expect(result.reasons).toContain(ReferralFraudReason.SUSPICIOUS_WITHDRAWAL);
+  });
+});

--- a/backend/src/modules/referrals/referral-fraud-detection.service.ts
+++ b/backend/src/modules/referrals/referral-fraud-detection.service.ts
@@ -1,0 +1,327 @@
+import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThan, Repository } from 'typeorm';
+import { createHash } from 'crypto';
+import { Referral } from './entities/referral.entity';
+import { ReferralFraudAudit } from './entities/referral-fraud-audit.entity';
+import {
+  ReferralFraudEvaluationContext,
+  ReferralFraudEvaluationResult,
+  ReferralFraudReason,
+} from './referral-fraud.types';
+import { ReferralStatus } from './entities/referral.entity';
+import {
+  Transaction,
+  TxType,
+} from '../transactions/entities/transaction.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+} from '../../common/entities/audit-log.entity';
+
+@Injectable()
+export class ReferralFraudDetectionService {
+  private readonly logger = new Logger(ReferralFraudDetectionService.name);
+  private readonly creationAttempts = new Map<string, number[]>();
+
+  constructor(
+    @InjectRepository(Referral)
+    private readonly referralRepository: Repository<Referral>,
+    @InjectRepository(ReferralFraudAudit)
+    private readonly fraudAuditRepository: Repository<ReferralFraudAudit>,
+    @InjectRepository(Transaction)
+    private readonly transactionRepository: Repository<Transaction>,
+    private readonly configService: ConfigService,
+    private readonly auditLogService: AuditLogService,
+  ) {}
+
+  buildMetadataFingerprint(
+    context: ReferralFraudEvaluationContext,
+  ): string | null {
+    return this.metadataFingerprint(context);
+  }
+
+  enforceCreationRateLimit(referrerId: string): void {
+    const windowMs = this.configService.get<number>(
+      'referralFraud.creationRateWindowMs',
+      3_600_000,
+    );
+    const maxAttempts = this.configService.get<number>(
+      'referralFraud.maxCreationAttemptsPerWindow',
+      20,
+    );
+
+    const now = Date.now();
+    const attempts = (this.creationAttempts.get(referrerId) ?? []).filter(
+      (ts) => now - ts <= windowMs,
+    );
+
+    if (attempts.length >= maxAttempts) {
+      throw new HttpException(
+        'Referral creation rate limit exceeded',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    attempts.push(now);
+    this.creationAttempts.set(referrerId, attempts);
+  }
+
+  async evaluateReferral(
+    referral: Referral,
+    context: ReferralFraudEvaluationContext = {},
+  ): Promise<ReferralFraudEvaluationResult> {
+    const reasons: ReferralFraudReason[] = [];
+    const metadata: Record<string, unknown> = { context };
+
+    if (referral.referrerId === referral.refereeId) {
+      reasons.push(ReferralFraudReason.SELF_REFERRAL);
+    }
+
+    const similarMetadata = await this.detectSimilarMetadata(referral, context);
+    if (similarMetadata) {
+      reasons.push(ReferralFraudReason.SIMILAR_METADATA);
+      metadata.similarMetadata = similarMetadata;
+    }
+
+    const suspiciousSignup = await this.detectSuspiciousSignupPattern(referral);
+    if (suspiciousSignup) {
+      reasons.push(ReferralFraudReason.SUSPICIOUS_SIGNUP_PATTERN);
+      metadata.suspiciousSignup = suspiciousSignup;
+    }
+
+    const excessiveCreation = await this.detectExcessiveReferralCreation(
+      referral.referrerId,
+    );
+    if (excessiveCreation) {
+      reasons.push(ReferralFraudReason.EXCESSIVE_CREATION);
+      metadata.excessiveCreation = excessiveCreation;
+    }
+
+    if (referral.refereeId) {
+      const withdrawalPattern = await this.detectSuspiciousWithdrawal(
+        referral.refereeId,
+      );
+      if (withdrawalPattern) {
+        reasons.push(ReferralFraudReason.SUSPICIOUS_WITHDRAWAL);
+        metadata.withdrawalPattern = withdrawalPattern;
+      }
+    }
+
+    const isSuspicious = reasons.length > 0;
+    return {
+      isSuspicious,
+      reasons,
+      metadata,
+      shouldQuarantine: isSuspicious,
+    };
+  }
+
+  async quarantineReferral(
+    referral: Referral,
+    evaluation: ReferralFraudEvaluationResult,
+    actor = 'system',
+  ): Promise<Referral> {
+    referral.status = ReferralStatus.QUARANTINED;
+    referral.fraudReasons = evaluation.reasons;
+    referral.quarantinedAt = new Date();
+    referral.requiresManualReview = true;
+
+    const saved = await this.referralRepository.save(referral);
+
+    const rationale = this.buildRationale(evaluation.reasons);
+    await this.fraudAuditRepository.save(
+      this.fraudAuditRepository.create({
+        referralId: referral.id,
+        referrerId: referral.referrerId,
+        refereeId: referral.refereeId,
+        reasons: evaluation.reasons,
+        decisionMetadata: evaluation.metadata,
+        rationale,
+        action: 'quarantine',
+        actor,
+      }),
+    );
+
+    await this.auditLogService.log({
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.USER,
+      resourceId: referral.id,
+      actor,
+      description: 'Referral quarantined by fraud detection',
+      previousValue: { status: ReferralStatus.PENDING },
+      newValue: {
+        status: ReferralStatus.QUARANTINED,
+        reasons: evaluation.reasons,
+        rationale,
+      },
+      success: true,
+    });
+
+    this.logger.warn(
+      `Referral ${referral.id} quarantined: ${evaluation.reasons.join(', ')}`,
+    );
+
+    return saved;
+  }
+
+  private buildRationale(reasons: ReferralFraudReason[]): string {
+    return reasons
+      .map((reason) => {
+        switch (reason) {
+          case ReferralFraudReason.SELF_REFERRAL:
+            return 'Referrer and referee resolve to the same user';
+          case ReferralFraudReason.SIMILAR_METADATA:
+            return 'Referral metadata closely matches prior suspicious attempts';
+          case ReferralFraudReason.SUSPICIOUS_SIGNUP_PATTERN:
+            return 'Referee signup pattern matches known abuse heuristics';
+          case ReferralFraudReason.EXCESSIVE_CREATION:
+            return 'Referrer exceeded configurable referral creation threshold';
+          case ReferralFraudReason.RATE_LIMIT_EXCEEDED:
+            return 'Referral creation rate limit exceeded';
+          case ReferralFraudReason.SUSPICIOUS_WITHDRAWAL:
+            return 'Referee exhibited deposit-then-immediate-withdrawal pattern';
+          default:
+            return reason;
+        }
+      })
+      .join('; ');
+  }
+
+  private metadataFingerprint(
+    context: ReferralFraudEvaluationContext,
+  ): string | null {
+    const parts = [
+      context.ipAddress,
+      context.userAgent,
+      context.deviceFingerprint,
+      context.signupSource,
+    ].filter(Boolean);
+
+    if (parts.length === 0) {
+      return null;
+    }
+
+    return createHash('sha256').update(parts.join('|')).digest('hex');
+  }
+
+  private async detectSimilarMetadata(
+    referral: Referral,
+    context: ReferralFraudEvaluationContext,
+  ): Promise<Record<string, unknown> | null> {
+    const fingerprint = this.metadataFingerprint(context);
+    if (!fingerprint) {
+      return null;
+    }
+
+    const windowMs = this.configService.get<number>(
+      'referralFraud.similarMetadataWindowMs',
+      7 * 24 * 60 * 60 * 1000,
+    );
+    const threshold = this.configService.get<number>(
+      'referralFraud.similarMetadataThreshold',
+      2,
+    );
+
+    const since = new Date(Date.now() - windowMs);
+    const recentReferrals = await this.referralRepository.find({
+      where: {
+        referrerId: referral.referrerId,
+        createdAt: MoreThan(since),
+      },
+    });
+
+    const matches = recentReferrals.filter((item) => {
+      const storedFingerprint = item.metadata?.fingerprint as
+        string | undefined;
+      return storedFingerprint === fingerprint && item.id !== referral.id;
+    });
+
+    if (matches.length >= threshold) {
+      return { fingerprint, matchCount: matches.length + 1 };
+    }
+
+    return null;
+  }
+
+  private async detectSuspiciousSignupPattern(
+    referral: Referral,
+  ): Promise<Record<string, unknown> | null> {
+    const windowMs = this.configService.get<number>(
+      'referralFraud.signupPatternWindowMs',
+      24 * 60 * 60 * 1000,
+    );
+    const threshold = this.configService.get<number>(
+      'referralFraud.signupPatternThreshold',
+      5,
+    );
+
+    const recentCount = await this.referralRepository.count({
+      where: {
+        referrerId: referral.referrerId,
+        createdAt: MoreThan(new Date(Date.now() - windowMs)),
+      },
+    });
+
+    if (recentCount >= threshold) {
+      return { recentCount, windowMs, threshold };
+    }
+
+    return null;
+  }
+
+  private async detectExcessiveReferralCreation(
+    referrerId: string,
+  ): Promise<Record<string, unknown> | null> {
+    const windowMs = this.configService.get<number>(
+      'referralFraud.excessiveCreationWindowMs',
+      24 * 60 * 60 * 1000,
+    );
+    const threshold = this.configService.get<number>(
+      'referralFraud.excessiveCreationThreshold',
+      10,
+    );
+
+    const count = await this.referralRepository.count({
+      where: {
+        referrerId,
+        createdAt: MoreThan(new Date(Date.now() - windowMs)),
+      },
+    });
+
+    if (count > threshold) {
+      return { count, threshold, windowMs };
+    }
+
+    return null;
+  }
+
+  private async detectSuspiciousWithdrawal(
+    refereeId: string,
+  ): Promise<Record<string, unknown> | null> {
+    const transactions = await this.transactionRepository.find({
+      where: { userId: refereeId },
+    });
+
+    const deposits = transactions.filter((t) => t.type === TxType.DEPOSIT);
+    const withdrawals = transactions.filter((t) => t.type === TxType.WITHDRAW);
+
+    if (deposits.length === 1 && withdrawals.length > 0) {
+      const timeDiff =
+        new Date(withdrawals[0].createdAt).getTime() -
+        new Date(deposits[0].createdAt).getTime();
+      const maxDiffMs = this.configService.get<number>(
+        'referralFraud.suspiciousWithdrawalWindowMs',
+        60 * 60 * 1000,
+      );
+
+      if (timeDiff < maxDiffMs) {
+        return { timeDiffMs: timeDiff, maxDiffMs };
+      }
+    }
+
+    return null;
+  }
+}

--- a/backend/src/modules/referrals/referral-fraud.types.ts
+++ b/backend/src/modules/referrals/referral-fraud.types.ts
@@ -1,0 +1,23 @@
+export enum ReferralFraudReason {
+  SELF_REFERRAL = 'self_referral',
+  SIMILAR_METADATA = 'similar_metadata',
+  SUSPICIOUS_SIGNUP_PATTERN = 'suspicious_signup_pattern',
+  EXCESSIVE_CREATION = 'excessive_creation',
+  RATE_LIMIT_EXCEEDED = 'rate_limit_exceeded',
+  RAPID_COMPLETION = 'rapid_completion',
+  SUSPICIOUS_WITHDRAWAL = 'suspicious_withdrawal',
+}
+
+export interface ReferralFraudEvaluationContext {
+  ipAddress?: string;
+  userAgent?: string;
+  deviceFingerprint?: string;
+  signupSource?: string;
+}
+
+export interface ReferralFraudEvaluationResult {
+  isSuspicious: boolean;
+  reasons: ReferralFraudReason[];
+  metadata: Record<string, unknown>;
+  shouldQuarantine: boolean;
+}

--- a/backend/src/modules/referrals/referrals.integration.spec.ts
+++ b/backend/src/modules/referrals/referrals.integration.spec.ts
@@ -7,9 +7,12 @@ import request from 'supertest';
 import { ReferralsModule } from './referrals.module';
 import { UserModule } from '../user/user.module';
 import { AuthModule } from '../../auth/auth.module';
+import { CommonModule } from '../../common/common.module';
 import { Referral } from './entities/referral.entity';
 import { ReferralCampaign } from './entities/referral-campaign.entity';
-import { User } from '../user/entities/user.entity';
+import { ReferralFraudAudit } from './entities/referral-fraud-audit.entity';
+import { Transaction } from '../transactions/entities/transaction.entity';
+import { AuditLog } from '../../common/entities/audit-log.entity';
 
 describe('Referrals Integration Tests', () => {
   let app: INestApplication;
@@ -22,7 +25,12 @@ describe('Referrals Integration Tests', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [() => ({ jwt: { secret: 'test-secret-key' } })],
+          load: [
+            () => ({
+              jwt: { secret: 'test-secret-key' },
+              referralFraud: {},
+            }),
+          ],
         }),
         TypeOrmModule.forRoot({
           type: 'postgres',
@@ -31,7 +39,14 @@ describe('Referrals Integration Tests', () => {
           database: process.env.DB_NAME || 'test_db',
           username: process.env.DB_USER || 'postgres',
           password: process.env.DB_PASS || 'postgres',
-          entities: [User, Referral, ReferralCampaign],
+          entities: [
+            User,
+            Referral,
+            ReferralCampaign,
+            ReferralFraudAudit,
+            Transaction,
+            AuditLog,
+          ],
           synchronize: true,
           dropSchema: true,
           // Fail fast instead of retrying when DB is unavailable
@@ -39,6 +54,7 @@ describe('Referrals Integration Tests', () => {
           retryDelay: 500,
         }),
         EventEmitterModule.forRoot(),
+        CommonModule,
         ReferralsModule,
         UserModule,
         AuthModule,

--- a/backend/src/modules/referrals/referrals.module.ts
+++ b/backend/src/modules/referrals/referrals.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Referral } from './entities/referral.entity';
 import { ReferralCampaign } from './entities/referral-campaign.entity';
+import { ReferralFraudAudit } from './entities/referral-fraud-audit.entity';
 import { User } from '../user/entities/user.entity';
 import { Transaction } from '../transactions/entities/transaction.entity';
 import { Notification } from '../notifications/entities/notification.entity';
 import { ReferralsService } from './referrals.service';
 import { CampaignsService } from './campaigns.service';
 import { ReferralAnalyticsService } from './referral-analytics.service';
+import { ReferralFraudDetectionService } from './referral-fraud-detection.service';
 import { ReferralsController } from './referrals.controller';
 import { AdminReferralsController } from './admin-referrals.controller';
 import { UserReferralsController } from './user-referrals.controller';
@@ -19,6 +21,7 @@ import { ReferralEventsListener } from './referral-events.listener';
     TypeOrmModule.forFeature([
       Referral,
       ReferralCampaign,
+      ReferralFraudAudit,
       User,
       Transaction,
       Notification,
@@ -34,8 +37,14 @@ import { ReferralEventsListener } from './referral-events.listener';
     ReferralsService,
     CampaignsService,
     ReferralAnalyticsService,
+    ReferralFraudDetectionService,
     ReferralEventsListener,
   ],
-  exports: [ReferralsService, CampaignsService, ReferralAnalyticsService],
+  exports: [
+    ReferralsService,
+    CampaignsService,
+    ReferralAnalyticsService,
+    ReferralFraudDetectionService,
+  ],
 })
 export class ReferralsModule {}

--- a/backend/src/modules/referrals/referrals.service.spec.ts
+++ b/backend/src/modules/referrals/referrals.service.spec.ts
@@ -3,10 +3,10 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ReferralsService } from './referrals.service';
+import { ReferralFraudDetectionService } from './referral-fraud-detection.service';
 import { Referral, ReferralStatus } from './entities/referral.entity';
 import { ReferralCampaign } from './entities/referral-campaign.entity';
 import { User } from '../user/entities/user.entity';
-import { Transaction } from '../transactions/entities/transaction.entity';
 import {
   NotFoundException,
   BadRequestException,
@@ -18,8 +18,8 @@ describe('ReferralsService', () => {
   let referralRepository: Repository<Referral>;
   let campaignRepository: Repository<ReferralCampaign>;
   let userRepository: Repository<User>;
-  let transactionRepository: Repository<Transaction>;
   let eventEmitter: EventEmitter2;
+  let fraudDetectionService: jest.Mocked<ReferralFraudDetectionService>;
 
   const mockUser = {
     id: 'user-1',
@@ -39,6 +39,18 @@ describe('ReferralsService', () => {
   };
 
   beforeEach(async () => {
+    fraudDetectionService = {
+      enforceCreationRateLimit: jest.fn(),
+      evaluateReferral: jest.fn().mockResolvedValue({
+        isSuspicious: false,
+        reasons: [],
+        metadata: {},
+        shouldQuarantine: false,
+      }),
+      quarantineReferral: jest.fn(),
+      buildMetadataFingerprint: jest.fn().mockReturnValue(null),
+    } as unknown as jest.Mocked<ReferralFraudDetectionService>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReferralsService,
@@ -66,16 +78,14 @@ describe('ReferralsService', () => {
           },
         },
         {
-          provide: getRepositoryToken(Transaction),
-          useValue: {
-            find: jest.fn(),
-          },
-        },
-        {
           provide: EventEmitter2,
           useValue: {
             emit: jest.fn(),
           },
+        },
+        {
+          provide: ReferralFraudDetectionService,
+          useValue: fraudDetectionService,
         },
       ],
     }).compile();
@@ -88,9 +98,6 @@ describe('ReferralsService', () => {
       getRepositoryToken(ReferralCampaign),
     );
     userRepository = module.get<Repository<User>>(getRepositoryToken(User));
-    transactionRepository = module.get<Repository<Transaction>>(
-      getRepositoryToken(Transaction),
-    );
     eventEmitter = module.get<EventEmitter2>(EventEmitter2);
   });
 

--- a/backend/src/modules/referrals/referrals.service.ts
+++ b/backend/src/modules/referrals/referrals.service.ts
@@ -6,16 +6,14 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan, IsNull } from 'typeorm';
+import { Repository, IsNull } from 'typeorm';
 import { Referral, ReferralStatus } from './entities/referral.entity';
 import { ReferralCampaign } from './entities/referral-campaign.entity';
 import { User } from '../user/entities/user.entity';
-import {
-  Transaction,
-  TxType,
-} from '../transactions/entities/transaction.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomBytes } from 'crypto';
+import { ReferralFraudDetectionService } from './referral-fraud-detection.service';
+import { ReferralFraudEvaluationContext } from './referral-fraud.types';
 
 @Injectable()
 export class ReferralsService {
@@ -28,9 +26,8 @@ export class ReferralsService {
     private campaignRepository: Repository<ReferralCampaign>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
-    @InjectRepository(Transaction)
-    private transactionRepository: Repository<Transaction>,
     private eventEmitter: EventEmitter2,
+    private readonly fraudDetectionService: ReferralFraudDetectionService,
   ) {}
 
   /**
@@ -40,6 +37,8 @@ export class ReferralsService {
     userId: string,
     campaignId?: string,
   ): Promise<Referral> {
+    this.fraudDetectionService.enforceCreationRateLimit(userId);
+
     const user = await this.userRepository.findOne({ where: { id: userId } });
     if (!user) {
       throw new NotFoundException('User not found');
@@ -84,6 +83,7 @@ export class ReferralsService {
   async applyReferralCode(
     referralCode: string,
     refereeId: string,
+    context: ReferralFraudEvaluationContext = {},
   ): Promise<void> {
     const referral = await this.referralRepository.findOne({
       where: { referralCode },
@@ -99,6 +99,11 @@ export class ReferralsService {
     }
 
     if (referral.referrerId === refereeId) {
+      const evaluation = await this.fraudDetectionService.evaluateReferral(
+        { ...referral, refereeId },
+        context,
+      );
+      await this.fraudDetectionService.quarantineReferral(referral, evaluation);
       throw new BadRequestException('Cannot use your own referral code');
     }
 
@@ -125,6 +130,26 @@ export class ReferralsService {
     }
 
     referral.refereeId = refereeId;
+    const fingerprint =
+      this.fraudDetectionService.buildMetadataFingerprint(context);
+    referral.metadata = {
+      ...(referral.metadata ?? {}),
+      fingerprint: fingerprint ?? undefined,
+      appliedAt: new Date().toISOString(),
+      ...context,
+    };
+
+    const evaluation = await this.fraudDetectionService.evaluateReferral(
+      referral,
+      context,
+    );
+    if (evaluation.shouldQuarantine) {
+      await this.fraudDetectionService.quarantineReferral(referral, evaluation);
+      throw new BadRequestException(
+        'Referral flagged for manual review due to suspicious activity',
+      );
+    }
+
     await this.referralRepository.save(referral);
 
     this.logger.log(
@@ -159,12 +184,10 @@ export class ReferralsService {
       return;
     }
 
-    // Fraud detection checks
-    const isFraudulent = await this.detectFraud(referral);
-    if (isFraudulent) {
-      referral.status = ReferralStatus.FRAUDULENT;
-      await this.referralRepository.save(referral);
-      this.logger.warn(`Fraudulent referral detected: ${referral.id}`);
+    const evaluation =
+      await this.fraudDetectionService.evaluateReferral(referral);
+    if (evaluation.shouldQuarantine) {
+      await this.fraudDetectionService.quarantineReferral(referral, evaluation);
       return;
     }
 
@@ -397,55 +420,6 @@ export class ReferralsService {
     const leaderboard = await this.getLeaderboard(1000);
     const entry = leaderboard.find((e) => e.userId === userId);
     return entry ? entry.rank : null;
-  }
-
-  /**
-   * Fraud detection logic
-   */
-  private async detectFraud(referral: Referral): Promise<boolean> {
-    // Check 1: Same IP address (would need IP tracking in metadata)
-    // Check 2: Rapid signups from same referrer
-    const recentReferrals = await this.referralRepository.count({
-      where: {
-        referrerId: referral.referrerId,
-        createdAt: MoreThan(new Date(Date.now() - 24 * 60 * 60 * 1000)), // Last 24 hours
-      },
-    });
-
-    if (recentReferrals > 10) {
-      this.logger.warn(
-        `Suspicious activity: ${recentReferrals} referrals in 24h`,
-      );
-      return true;
-    }
-
-    // Check 3: Referee has suspicious transaction patterns
-    if (referral.refereeId) {
-      const transactions = await this.transactionRepository.find({
-        where: { userId: referral.refereeId },
-      });
-
-      // If only one deposit and immediate withdrawal, flag as suspicious
-      const deposits = transactions.filter((t) => t.type === TxType.DEPOSIT);
-      const withdrawals = transactions.filter(
-        (t) => t.type === TxType.WITHDRAW,
-      );
-
-      if (deposits.length === 1 && withdrawals.length > 0) {
-        const timeDiff =
-          new Date(withdrawals[0].createdAt).getTime() -
-          new Date(deposits[0].createdAt).getTime();
-        if (timeDiff < 60 * 60 * 1000) {
-          // Less than 1 hour
-          this.logger.warn(
-            `Suspicious withdrawal pattern for user ${referral.refereeId}`,
-          );
-          return true;
-        }
-      }
-    }
-
-    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds `ReferralFraudDetectionService` with configurable heuristics for self-referrals, similar metadata, suspicious signup patterns, excessive creation, and suspicious withdrawals.
- Quarantines suspicious referrals, blocks automatic reward completion, and persists immutable `referral_fraud_audits` records.

## Fraud detection architecture
- Deterministic rule evaluation with configurable `referralFraud.*` thresholds.
- Rate limiting on referral code creation.
- Metadata fingerprinting for repeated suspicious attempts.

## Audit trail
- Immutable fraud audit rows + `AuditLogService` integration for quarantine decisions.

Closes #1016

Made with [Cursor](https://cursor.com)