### PR TITLE
feat: implement structured audit logging for user actions (#1033)

### DIFF
--- a/LOGGING_IMPLEMENTATION.md
+++ b/LOGGING_IMPLEMENTATION.md
@@ -371,6 +371,66 @@ NODE_ENV=production npm start
 - Check environment variables (API keys, region, etc.)
 - Test with `console.log` to ensure stdout is captured
 
+## Audit Log Database Retention Policy
+
+The audit log entries stored in the database (`audit_logs` table) are subject to a configurable retention policy separate from the Pino log transport layer above.
+
+### Retention Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `audit.retentionDays` | `90` | How long (in days) audit log rows are kept in the primary database |
+
+Configured via environment or config:
+```bash
+# .env
+AUDIT_RETENTION_DAYS=90
+```
+
+### Cleanup
+
+The `AdminAuditLogsService.cleanupOldLogs()` method deletes rows older than `retentionDays`:
+- Called on-demand via `POST /admin/audit-logs/cleanup`
+- Deletes all rows where `timestamp < NOW() - retentionDays`
+- Returns the count of deleted rows
+
+### Archival (Automated)
+
+The `AdminAuditLogsArchivalService` runs daily at **01:00 UTC** via a `@Cron('0 1 * * *')` scheduled task:
+
+1. **Batch read** — fetches logs older than retention in batches of 10,000 (configurable via `audit.archivalBatchSize`)
+2. **Local file** — writes each batch to a JSONL file (`audit-logs-{timestamp}.jsonl`)
+3. **Compression** — gzips the file (enabled by default via `audit.compression.enabled`)
+4. **Cold storage** — uploads to S3 Glacier when `audit.coldStorage.enabled` is true (requires `audit.coldStorage.s3Bucket`, `awsAccessKeyId`, `awsSecretAccessKey`)
+5. **Deletion** — removes the archived rows from the primary database
+
+### Cold Storage Configuration
+
+```bash
+AUDIT_COLD_STORAGE_ENABLED=true
+AUDIT_COLD_STORAGE_S3_BUCKET=nestera-audit-logs
+AUDIT_COLD_STORAGE_REGION=us-east-1
+AUDIT_COLD_STORAGE_AWS_ACCESS_KEY_ID=...
+AUDIT_COLD_STORAGE_AWS_SECRET_ACCESS_KEY=...
+AUDIT_COMPRESSION_ENABLED=true
+AUDIT_ARCHIVE_PATH=/var/archive/audit-logs
+AUDIT_ARCHIVAL_BATCH_SIZE=10000
+```
+
+### Verification
+
+Query retention policy status:
+```bash
+GET /admin/audit-logs/retention-policy
+# → { "retentionDays": 90, "configured": true }
+```
+
+Query archival statistics:
+```bash
+GET /admin/audit-logs/stats
+# → { totalLogsInDb, logsOlderThanRetention, retentionDays, estimatedStorageGb }
+```
+
 ## Future Enhancements
 
 - Add request/response size tracking

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -147,6 +147,54 @@ GROUP BY error_message
 ORDER BY count DESC;
 ```
 
+### 6. User Action Audit Events
+
+User-initiated actions are logged with specific action types and resource types for auditability:
+
+| Action | Resource Type | Description |
+|--------|---------------|-------------|
+| `DEPOSIT` | `SAVINGS` | User subscribes to a savings product (initiates a deposit) |
+| `WITHDRAW` | `WITHDRAWAL_REQUEST` | User requests a withdrawal from a subscription |
+| `CREATE` | `DISPUTE` | User submits a new dispute on a claim |
+| `VOTE` | `GOVERNANCE` | User casts a vote (for/against/abstain) on a governance proposal |
+
+These entries include `correlationId`, `actor` (user ID), `resourceId`, and `description` for full traceability.
+
+```sql
+-- Find all deposit actions by a user
+SELECT
+  correlation_id,
+  timestamp,
+  description,
+  new_value
+FROM audit_logs
+WHERE action = 'DEPOSIT'
+  AND actor = 'user-uuid'
+ORDER BY timestamp DESC;
+
+-- Find all withdrawal requests
+SELECT
+  correlation_id,
+  timestamp,
+  description,
+  new_value
+FROM audit_logs
+WHERE action = 'WITHDRAW'
+  AND actor = 'user-uuid'
+ORDER BY timestamp DESC;
+
+-- Find all votes by a user
+SELECT
+  correlation_id,
+  timestamp,
+  description,
+  new_value
+FROM audit_logs
+WHERE action = 'VOTE'
+  AND actor = 'user-uuid'
+ORDER BY timestamp DESC;
+```
+
 ## Common Incident Scenarios
 
 ### Scenario 1: Claim Status Changed Unexpectedly
@@ -379,7 +427,11 @@ HAVING COUNT(*) > 3;
 
 ## Retention Policy
 
-- **Audit Logs**: Retained for 90 days (configurable)
+- **Audit Logs**: Retained for 90 days (configurable via `audit.retentionDays` env var). This applies to all entries in the `audit_logs` table, covering both admin actions and user actions (deposits, withdrawals, disputes, votes, etc.).
+  - A scheduled cron job (`AdminAuditLogsArchivalService`) runs daily at 01:00 UTC to archive and purge logs older than the retention window.
+  - Archived logs are compressed (gzip) and optionally uploaded to S3 Glacier for cold storage.
+  - The archive includes all audit fields: correlationId, actor, action, resourceType, resourceId, description, previous/new values, IP address, and user agent.
+  - User action audit entries are retained under the same policy as admin audit entries.
 - **Application Logs**: Retained for 30 days
 - **Contract Events**: Retained indefinitely (immutable on blockchain)
 

--- a/backend/src/common/decorators/request-id.decorator.ts
+++ b/backend/src/common/decorators/request-id.decorator.ts
@@ -1,0 +1,12 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const RequestId = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return (
+      request.requestId ||
+      request.correlationId ||
+      request.headers['x-request-id']
+    );
+  },
+);

--- a/backend/src/common/entities/audit-log.entity.ts
+++ b/backend/src/common/entities/audit-log.entity.ts
@@ -32,6 +32,9 @@ export enum AuditAction {
   RESOLVE = 'RESOLVE',
   ASSIGN = 'ASSIGN',
   EXPORT = 'EXPORT',
+  DEPOSIT = 'DEPOSIT',
+  WITHDRAW = 'WITHDRAW',
+  VOTE = 'VOTE',
 }
 
 export enum AuditResourceType {
@@ -46,6 +49,7 @@ export enum AuditResourceType {
   ADMIN = 'ADMIN',
   WITHDRAWAL_REQUEST = 'WITHDRAWAL_REQUEST',
   SYSTEM = 'SYSTEM',
+  GOVERNANCE = 'GOVERNANCE',
 }
 
 @Entity('audit_logs')
@@ -61,6 +65,9 @@ export class AuditLog {
 
   @Column({ nullable: true })
   correlationId: string;
+
+  @Column({ nullable: true })
+  requestId: string;
 
   @CreateDateColumn()
   timestamp: Date;

--- a/backend/src/common/interceptors/audit-log.interceptor.ts
+++ b/backend/src/common/interceptors/audit-log.interceptor.ts
@@ -34,6 +34,7 @@ export class AuditLogInterceptor implements NestInterceptor {
 
     // Extract correlation ID from request
     const correlationId = (request as any).correlationId || 'unknown';
+    const requestId = (request as any).requestId || correlationId;
 
     // Determine if this is a mutation endpoint (POST, PATCH, PUT, DELETE)
     const isMutation = ['POST', 'PATCH', 'PUT', 'DELETE'].includes(
@@ -52,7 +53,7 @@ export class AuditLogInterceptor implements NestInterceptor {
     }
 
     const startTime = Date.now();
-    const auditEntry = this.buildAuditEntry(request, correlationId);
+    const auditEntry = this.buildAuditEntry(request, correlationId, requestId);
 
     return next.handle().pipe(
       tap((data) => {
@@ -78,7 +79,11 @@ export class AuditLogInterceptor implements NestInterceptor {
     );
   }
 
-  private buildAuditEntry(request: Request, correlationId: string) {
+  private buildAuditEntry(
+    request: Request,
+    correlationId: string,
+    requestId: string,
+  ) {
     const body = request.body || {};
     const params = request.params || {};
 
@@ -100,6 +105,7 @@ export class AuditLogInterceptor implements NestInterceptor {
 
     return {
       correlationId,
+      requestId,
       timestamp: new Date().toISOString(),
       endpoint: request.url,
       method: request.method,

--- a/backend/src/common/interceptors/correlation-id.interceptor.ts
+++ b/backend/src/common/interceptors/correlation-id.interceptor.ts
@@ -23,14 +23,20 @@ export class CorrelationIdInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context
       .switchToHttp()
-      .getRequest<Request & { correlationId?: string }>();
+      .getRequest<Request & { correlationId?: string; requestId?: string }>();
     const response = context.switchToHttp().getResponse<Response>();
 
-    // Ensure ID exists (middleware should have set this, but guard against it)
+    // Ensure correlationId exists (middleware should have set this, but guard against it)
     if (!request.correlationId) {
       const id = (request.headers['x-correlation-id'] as string) || uuidv4();
       request.correlationId = id;
       response.setHeader('x-correlation-id', id);
+    }
+
+    // Ensure requestId exists
+    if (!request.requestId) {
+      const id = (request.headers['x-request-id'] as string) || uuidv4();
+      request.requestId = id;
     }
 
     return next.handle();

--- a/backend/src/common/middleware/correlation-id.middleware.ts
+++ b/backend/src/common/middleware/correlation-id.middleware.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export type RequestWithCorrelation = Request & {
   correlationId: string;
+  requestId: string;
   startTime: number;
 };
 
@@ -22,15 +23,15 @@ export type RequestWithCorrelation = Request & {
 @Injectable()
 export class CorrelationIdMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction) {
-    // Accept from either casing — normalize to lowercase internally
-    const incomingId =
-      (req.headers['x-correlation-id'] as string) ||
-      (req.headers['x-request-id'] as string);
-
-    const correlationId = incomingId || uuidv4();
-
-    // Attach to request for downstream access
     const reqWithCorrelation = req as RequestWithCorrelation;
+
+    // Extract requestId from X-Request-ID header, or generate a unique UUID
+    const requestId = (req.headers['x-request-id'] as string) || uuidv4();
+    reqWithCorrelation.requestId = requestId;
+
+    // Extract correlationId from X-Correlation-ID header, default to requestId
+    const correlationId =
+      (req.headers['x-correlation-id'] as string) || requestId;
     reqWithCorrelation.correlationId = correlationId;
     reqWithCorrelation.startTime = Date.now();
 

--- a/backend/src/common/services/audit-log.service.ts
+++ b/backend/src/common/services/audit-log.service.ts
@@ -9,6 +9,7 @@ import {
 
 export interface CreateAuditLogDto {
   correlationId?: string;
+  requestId?: string;
   endpoint?: string;
   method?: string;
   action?: AuditAction;

--- a/backend/src/migrations/1775300000002-AddRequestIdToAuditLogs.ts
+++ b/backend/src/migrations/1775300000002-AddRequestIdToAuditLogs.ts
@@ -1,0 +1,33 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableIndex,
+} from 'typeorm';
+
+export class AddRequestIdToAuditLogs1775300000002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'audit_logs',
+      new TableColumn({
+        name: 'request_id',
+        type: 'varchar',
+        isNullable: true,
+        comment: 'Per-request unique ID for tracing',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({
+        name: 'idx_audit_logs_request_id',
+        columnNames: ['request_id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('audit_logs', 'idx_audit_logs_request_id');
+    await queryRunner.dropColumn('audit_logs', 'request_id');
+  }
+}

--- a/backend/src/modules/disputes/disputes.controller.ts
+++ b/backend/src/modules/disputes/disputes.controller.ts
@@ -11,6 +11,8 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { DisputesService } from './disputes.service';
+import { CorrelationId } from '../../common/decorators/correlation-id.decorator';
+import { RequestId } from '../../common/decorators/request-id.decorator';
 import {
   CreateDisputeDto,
   UpdateDisputeDto,
@@ -30,8 +32,14 @@ export class DisputesController {
   @ApiResponse({ status: 400, description: 'Invalid claim ID' })
   async createDispute(
     @Body() createDisputeDto: CreateDisputeDto,
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<Dispute> {
-    return await this.disputesService.createDispute(createDisputeDto);
+    return await this.disputesService.createDispute(
+      createDisputeDto,
+      correlationId,
+      requestId,
+    );
   }
 
   @Get()
@@ -91,8 +99,15 @@ export class DisputesController {
   async startInvestigation(
     @Param('id') id: string,
     @Query('actor') actor: string,
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<Dispute> {
-    return await this.disputesService.startInvestigation(id, actor);
+    return await this.disputesService.startInvestigation(
+      id,
+      actor,
+      correlationId,
+      requestId,
+    );
   }
 
   @Patch(':id/resolve')
@@ -103,8 +118,16 @@ export class DisputesController {
     @Param('id') id: string,
     @Query('actor') actor: string,
     @Body('resolution') resolution: string,
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<Dispute> {
-    return await this.disputesService.resolveDispute(id, actor, resolution);
+    return await this.disputesService.resolveDispute(
+      id,
+      actor,
+      resolution,
+      correlationId,
+      requestId,
+    );
   }
 
   @Patch(':id/close')
@@ -114,8 +137,15 @@ export class DisputesController {
   async closeDispute(
     @Param('id') id: string,
     @Query('actor') actor: string,
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<Dispute> {
-    return await this.disputesService.closeDispute(id, actor);
+    return await this.disputesService.closeDispute(
+      id,
+      actor,
+      correlationId,
+      requestId,
+    );
   }
 
   @Patch(':id/escalate')
@@ -125,7 +155,14 @@ export class DisputesController {
   async escalateDispute(
     @Param('id') id: string,
     @Query('actor') actor: string,
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<Dispute> {
-    return await this.disputesService.escalateDispute(id, actor);
+    return await this.disputesService.escalateDispute(
+      id,
+      actor,
+      correlationId,
+      requestId,
+    );
   }
 }

--- a/backend/src/modules/disputes/disputes.service.spec.ts
+++ b/backend/src/modules/disputes/disputes.service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from './entities/dispute.entity';
 import { MedicalClaim } from '../claims/entities/medical-claim.entity';
 import { NotificationsService } from '../notifications/notifications.service';
+import { AuditLogService } from '../../common/services/audit-log.service';
 import { BadRequestException } from '@nestjs/common';
 
 describe('DisputesService', () => {
@@ -62,6 +63,10 @@ describe('DisputesService', () => {
         {
           provide: NotificationsService,
           useValue: mockNotificationsService,
+        },
+        {
+          provide: AuditLogService,
+          useValue: { log: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/backend/src/modules/disputes/disputes.service.ts
+++ b/backend/src/modules/disputes/disputes.service.ts
@@ -19,6 +19,11 @@ import {
 } from './dto/dispute.dto';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+} from '../../common/entities/audit-log.entity';
 
 const ALLOWED_TRANSITIONS: Record<DisputeStatus, DisputeStatus[]> = {
   [DisputeStatus.OPEN]: [
@@ -70,9 +75,14 @@ export class DisputesService {
     @InjectRepository(DisputeTimeline)
     private readonly timelineRepository: Repository<DisputeTimeline>,
     private readonly notificationsService: NotificationsService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
-  async createDispute(createDisputeDto: CreateDisputeDto): Promise<Dispute> {
+  async createDispute(
+    createDisputeDto: CreateDisputeDto,
+    correlationId?: string,
+    requestId?: string,
+  ): Promise<Dispute> {
     const claim = await this.claimRepository.findOneBy({
       id: createDisputeDto.claimId,
     });
@@ -96,10 +106,20 @@ export class DisputesService {
       }),
     );
 
-    // Notify (in a real app, we'd notify the claim owner or admins)
-    // For now, let's just assume there's a way to find them.
-    // For demo, we'll skip actual notification to a specific user since we don't have user ID of claim owner here easily without more queries.
-    // But we can log it.
+    await this.auditLogService.log({
+      action: AuditAction.CREATE,
+      resourceType: AuditResourceType.DISPUTE,
+      actor: savedDispute.disputedBy || 'unknown',
+      correlationId,
+      requestId,
+      resourceId: savedDispute.id,
+      description: `User submitted dispute for claim ${createDisputeDto.claimId}`,
+      newValue: {
+        claimId: createDisputeDto.claimId,
+        reason: createDisputeDto.reason,
+      },
+      success: true,
+    });
 
     return savedDispute;
   }
@@ -156,7 +176,12 @@ export class DisputesService {
     return savedMessage;
   }
 
-  async startInvestigation(id: string, actor: string): Promise<Dispute> {
+  async startInvestigation(
+    id: string,
+    actor: string,
+    correlationId?: string,
+    requestId?: string,
+  ): Promise<Dispute> {
     const dispute = await this.findOne(id);
     const previousState = { status: dispute.status };
 
@@ -182,6 +207,19 @@ export class DisputesService {
       }),
     );
 
+    await this.auditLogService.log({
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.DISPUTE,
+      actor,
+      correlationId,
+      requestId,
+      resourceId: id,
+      description: `Investigation started on dispute ${id}`,
+      previousValue: previousState,
+      newValue: { status: DisputeStatus.UNDER_REVIEW, assignedTo: actor },
+      success: true,
+    });
+
     return updatedDispute;
   }
 
@@ -189,6 +227,8 @@ export class DisputesService {
     id: string,
     actor: string,
     resolution: string,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<Dispute> {
     const dispute = await this.findOne(id);
     const previousState = { status: dispute.status };
@@ -216,10 +256,32 @@ export class DisputesService {
       }),
     );
 
+    await this.auditLogService.log({
+      action: AuditAction.RESOLVE,
+      resourceType: AuditResourceType.DISPUTE,
+      actor,
+      correlationId,
+      requestId,
+      resourceId: id,
+      description: `Dispute ${id} resolved: ${resolution}`,
+      previousValue: previousState,
+      newValue: {
+        status: DisputeStatus.RESOLVED,
+        resolution,
+        resolvedBy: actor,
+      },
+      success: true,
+    });
+
     return updatedDispute;
   }
 
-  async closeDispute(id: string, actor: string): Promise<Dispute> {
+  async closeDispute(
+    id: string,
+    actor: string,
+    correlationId?: string,
+    requestId?: string,
+  ): Promise<Dispute> {
     const dispute = await this.findOne(id);
     const previousState = { status: dispute.status };
 
@@ -243,10 +305,28 @@ export class DisputesService {
       }),
     );
 
+    await this.auditLogService.log({
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.DISPUTE,
+      actor,
+      correlationId,
+      requestId,
+      resourceId: id,
+      description: `Dispute ${id} closed`,
+      previousValue: previousState,
+      newValue: { status: DisputeStatus.CLOSED },
+      success: true,
+    });
+
     return updatedDispute;
   }
 
-  async escalateDispute(id: string, actor: string): Promise<Dispute> {
+  async escalateDispute(
+    id: string,
+    actor: string,
+    correlationId?: string,
+    requestId?: string,
+  ): Promise<Dispute> {
     const dispute = await this.findOne(id);
     const previousState = { status: dispute.status };
 
@@ -271,6 +351,19 @@ export class DisputesService {
         newState: { status: dispute.status },
       }),
     );
+
+    await this.auditLogService.log({
+      action: AuditAction.ESCALATE,
+      resourceType: AuditResourceType.DISPUTE,
+      actor,
+      correlationId,
+      requestId,
+      resourceId: id,
+      description: `Dispute ${id} escalated to ${actor}`,
+      previousValue: previousState,
+      newValue: { status: DisputeStatus.ESCALATED, escalatedTo: actor },
+      success: true,
+    });
 
     return updatedDispute;
   }

--- a/backend/src/modules/governance/governance-proposals.controller.ts
+++ b/backend/src/modules/governance/governance-proposals.controller.ts
@@ -21,6 +21,8 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { CorrelationId } from '../../common/decorators/correlation-id.decorator';
+import { RequestId } from '../../common/decorators/request-id.decorator';
 import { CreateProposalDto } from './dto/create-proposal.dto';
 import { EditProposalDto } from './dto/edit-proposal.dto';
 import { CastVoteDto } from './dto/cast-vote.dto';
@@ -54,8 +56,15 @@ export class GovernanceProposalsController {
   createProposal(
     @CurrentUser() user: { id: string },
     @Body() dto: CreateProposalDto,
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<ProposalResponseDto> {
-    return this.governanceService.createProposal(user.id, dto);
+    return this.governanceService.createProposal(
+      user.id,
+      dto,
+      correlationId,
+      requestId,
+    );
   }
 
   @Post(':id/edit')
@@ -172,8 +181,16 @@ export class GovernanceProposalsController {
     @Param('id', ParseIntPipe) id: number,
     @Body() castVoteDto: CastVoteDto,
     @CurrentUser() user: { id: string },
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<{ transactionHash: string }> {
-    return this.governanceService.castVote(user.id, id, castVoteDto.direction);
+    return this.governanceService.castVote(
+      user.id,
+      id,
+      castVoteDto.direction,
+      correlationId,
+      requestId,
+    );
   }
 
   @Get(':id/votes')
@@ -246,8 +263,15 @@ export class GovernanceProposalsController {
   queueProposal(
     @Param('id') id: string,
     @CurrentUser() user: { id: string },
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<ProposalResponseDto> {
-    return this.governanceService.queueProposal(id, user.id);
+    return this.governanceService.queueProposal(
+      id,
+      user.id,
+      correlationId,
+      requestId,
+    );
   }
 
   @Post(':id/execute')
@@ -269,8 +293,15 @@ export class GovernanceProposalsController {
   executeProposal(
     @Param('id') id: string,
     @CurrentUser() user: { id: string },
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<ProposalResponseDto> {
-    return this.governanceService.executeProposal(id, user.id);
+    return this.governanceService.executeProposal(
+      id,
+      user.id,
+      correlationId,
+      requestId,
+    );
   }
 
   @Post(':id/cancel')
@@ -289,8 +320,16 @@ export class GovernanceProposalsController {
     @Param('id') id: string,
     @CurrentUser() user: { id: string },
     @Body('reason') reason?: string,
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<ProposalResponseDto> {
-    return this.governanceService.cancelProposal(id, user.id, reason);
+    return this.governanceService.cancelProposal(
+      id,
+      user.id,
+      reason,
+      correlationId,
+      requestId,
+    );
   }
 
   @Post(':id/finalize')
@@ -317,8 +356,15 @@ export class GovernanceProposalsController {
   finalizeProposal(
     @Param('id') id: string,
     @CurrentUser() user: { id: string },
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<ProposalResponseDto> {
-    return this.governanceService.finalizeVoting(id, user.id);
+    return this.governanceService.finalizeVoting(
+      id,
+      user.id,
+      correlationId,
+      requestId,
+    );
   }
 
   @Get(':id/transitions')
@@ -338,12 +384,12 @@ export class GovernanceProposalsController {
       items: {
         type: 'object',
         properties: {
-          id:            { type: 'string', format: 'uuid' },
-          fromStatus:    { type: 'string' },
-          toStatus:      { type: 'string' },
-          triggeredBy:   { type: 'string', nullable: true },
-          reason:        { type: 'string', nullable: true },
-          metadata:      { type: 'object', nullable: true },
+          id: { type: 'string', format: 'uuid' },
+          fromStatus: { type: 'string' },
+          toStatus: { type: 'string' },
+          triggeredBy: { type: 'string', nullable: true },
+          reason: { type: 'string', nullable: true },
+          metadata: { type: 'object', nullable: true },
           transitionedAt: { type: 'string', format: 'date-time' },
         },
       },

--- a/backend/src/modules/governance/governance.service.spec.ts
+++ b/backend/src/modules/governance/governance.service.spec.ts
@@ -17,6 +17,7 @@ import { Vote, VoteDirection } from './entities/vote.entity';
 import { Delegation } from './entities/delegation.entity';
 import { TransactionsService } from '../transactions/transactions.service';
 import { LedgerTransaction } from '../blockchain/entities/transaction.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
 
 describe('GovernanceService', () => {
   let service: GovernanceService;
@@ -107,6 +108,10 @@ describe('GovernanceService', () => {
         {
           provide: getRepositoryToken(Delegation),
           useValue: delegationRepo,
+        },
+        {
+          provide: AuditLogService,
+          useValue: { log: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/backend/src/modules/governance/governance.service.ts
+++ b/backend/src/modules/governance/governance.service.ts
@@ -38,6 +38,11 @@ import { ProposalLifecycleService } from './governance-lifecycle.service';
 import { VotingPowerResponseDto } from './dto/voting-power-response.dto';
 import { TxStatus, TxType } from '../transactions/entities/transaction.entity';
 import { LedgerTransaction } from '../blockchain/entities/transaction.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+} from '../../common/entities/audit-log.entity';
 
 /** Timelock duration in milliseconds (24 hours) */
 const TIMELOCK_DURATION_MS = 24 * 60 * 60 * 1000;
@@ -74,11 +79,14 @@ export class GovernanceService {
     private readonly transactionRepo: Repository<LedgerTransaction>,
     @InjectRepository(Delegation)
     private readonly delegationRepo: Repository<Delegation>,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   async createProposal(
     userId: string,
     dto: CreateProposalDto,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<ProposalResponseDto> {
     const user = await this.userService.findById(userId);
     if (!user.publicKey) {
@@ -176,6 +184,23 @@ export class GovernanceService {
     });
 
     const savedProposal = await this.proposalRepo.save(proposal);
+
+    await this.auditLogService.log({
+      action: AuditAction.CREATE,
+      resourceType: AuditResourceType.GOVERNANCE,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: savedProposal.id,
+      description: `User created proposal "${savedProposal.title}" (type: ${savedProposal.type})`,
+      newValue: {
+        onChainId: savedProposal.onChainId,
+        title: savedProposal.title,
+        type: savedProposal.type,
+        category: savedProposal.category,
+      },
+      success: true,
+    });
 
     this.eventEmitter.emit('governance.proposal.created', {
       proposalId: savedProposal.id,
@@ -379,6 +404,8 @@ export class GovernanceService {
     userId: string,
     onChainId: number,
     direction: VoteDirection,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<{ transactionHash: string }> {
     const user = await this.userService.findById(userId);
     if (!user.publicKey) {
@@ -406,9 +433,7 @@ export class GovernanceService {
     const voteDedupKey = `vote:${user.publicKey}:${proposal.id}`;
     const cachedDuplicate = await this.cacheStrategy.get<true>(voteDedupKey);
     if (cachedDuplicate) {
-      throw new ConflictException(
-        'You have already voted on this proposal',
-      );
+      throw new ConflictException('You have already voted on this proposal');
     }
 
     // ── Layer 2: authoritative DB read ────────────────────────────────────
@@ -424,9 +449,7 @@ export class GovernanceService {
         'vote',
         `proposal:${proposal.id}`,
       ]);
-      throw new ConflictException(
-        'You have already voted on this proposal',
-      );
+      throw new ConflictException('You have already voted on this proposal');
     }
 
     const votingPowerResult = await this.getUserVotingPower(userId);
@@ -476,6 +499,23 @@ export class GovernanceService {
       walletAddress: user.publicKey,
     });
 
+    await this.auditLogService.log({
+      action: AuditAction.VOTE,
+      resourceType: AuditResourceType.GOVERNANCE,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: String(proposal.onChainId),
+      description: `User voted ${direction} on proposal ${proposal.id} (onChainId: ${proposal.onChainId})`,
+      newValue: {
+        proposalId: proposal.id,
+        onChainId: proposal.onChainId,
+        direction,
+        weight,
+      },
+      success: true,
+    });
+
     return { transactionHash: mockTxHash };
   }
 
@@ -517,6 +557,8 @@ export class GovernanceService {
   async queueProposal(
     proposalId: string,
     userId: string,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<ProposalResponseDto> {
     const proposal = await this.proposalRepo.findOneBy({ id: proposalId });
     if (!proposal)
@@ -540,6 +582,21 @@ export class GovernanceService {
       reason: `Queued by ${userId}; timelock ends ${timelockEndsAt.toISOString()}`,
     });
 
+    await this.auditLogService.log({
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.GOVERNANCE,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: proposal.id,
+      description: `Proposal ${proposal.onChainId} queued for execution (timelock ends ${proposal.timelockEndsAt?.toISOString()})`,
+      newValue: {
+        status: ProposalStatus.QUEUED,
+        timelockEndsAt: proposal.timelockEndsAt,
+      },
+      success: true,
+    });
+
     this.eventEmitter.emit('governance.proposal.queued', {
       proposalId: proposal.id,
     });
@@ -551,6 +608,8 @@ export class GovernanceService {
   async executeProposal(
     proposalId: string,
     userId: string,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<ProposalResponseDto> {
     const proposal = await this.proposalRepo.findOneBy({ id: proposalId });
     if (!proposal)
@@ -578,6 +637,21 @@ export class GovernanceService {
       },
     );
 
+    await this.auditLogService.log({
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.GOVERNANCE,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: proposal.id,
+      description: `Proposal ${proposal.onChainId} executed`,
+      newValue: {
+        status: ProposalStatus.EXECUTED,
+        executedAt: proposal.executedAt,
+      },
+      success: true,
+    });
+
     this.eventEmitter.emit('governance.proposal.executed', {
       proposalId: proposal.id,
     });
@@ -590,6 +664,8 @@ export class GovernanceService {
     proposalId: string,
     userId: string,
     reason?: string,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<ProposalResponseDto> {
     const proposal = await this.proposalRepo.findOneBy({ id: proposalId });
     if (!proposal)
@@ -609,6 +685,18 @@ export class GovernanceService {
       },
     );
 
+    await this.auditLogService.log({
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.GOVERNANCE,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: proposal.id,
+      description: `Proposal ${proposal.onChainId} cancelled${reason ? `: ${reason}` : ''}`,
+      newValue: { status: ProposalStatus.CANCELLED, reason },
+      success: true,
+    });
+
     this.eventEmitter.emit('governance.proposal.cancelled', {
       proposalId: proposal.id,
     });
@@ -622,11 +710,26 @@ export class GovernanceService {
   async finalizeVoting(
     proposalId: string,
     userId: string,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<ProposalResponseDto> {
     const proposal = await this.lifecycleService.finalizeVoting(
       proposalId,
       userId,
     );
+
+    await this.auditLogService.log({
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.GOVERNANCE,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: proposal.id,
+      description: `Voting finalized for proposal ${proposal.onChainId} — status: ${proposal.status}`,
+      newValue: { status: proposal.status },
+      success: true,
+    });
+
     const currentLedger = await this.getCurrentLedger();
     return this.toProposalResponse(proposal, currentLedger);
   }

--- a/backend/src/modules/savings/savings.controller.ts
+++ b/backend/src/modules/savings/savings.controller.ts
@@ -51,6 +51,8 @@ import {
 import { RecommendationResponseDto } from './dto/recommendation-response.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { CorrelationId } from '../../common/decorators/correlation-id.decorator';
+import { RequestId } from '../../common/decorators/request-id.decorator';
 import { RpcThrottleGuard } from '../../common/guards/rpc-throttle.guard';
 import { Idempotent } from '../../common/decorators/idempotent.decorator';
 import { RecommendationService } from './services/recommendation.service';
@@ -235,11 +237,16 @@ export class SavingsController {
   async subscribe(
     @Body() dto: SubscribeDto,
     @CurrentUser() user: { id: string; email: string },
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<UserSubscription> {
     return await this.savingsService.subscribe(
       user.id,
       dto.productId,
       dto.amount,
+      false,
+      correlationId,
+      requestId,
     );
   }
 
@@ -269,12 +276,16 @@ export class SavingsController {
   async withdraw(
     @Body() dto: WithdrawDto,
     @CurrentUser() user: { id: string; email: string },
+    @CorrelationId() correlationId?: string,
+    @RequestId() requestId?: string,
   ): Promise<WithdrawalResponseDto> {
     const withdrawal = await this.savingsService.createWithdrawalRequest(
       user.id,
       dto.subscriptionId,
       dto.amount,
       dto.reason,
+      correlationId,
+      requestId,
     );
 
     return {

--- a/backend/src/modules/savings/savings.service.spec.ts
+++ b/backend/src/modules/savings/savings.service.spec.ts
@@ -15,6 +15,7 @@ import { ProductApySnapshot } from './entities/product-apy-snapshot.entity';
 import { WaitlistService } from './waitlist.service';
 import { WithdrawalRequest } from './entities/withdrawal-request.entity';
 import { Transaction } from '../transactions/entities/transaction.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
 
 describe('SavingsService', () => {
   let service: SavingsService;
@@ -143,6 +144,10 @@ describe('SavingsService', () => {
         {
           provide: CACHE_MANAGER,
           useValue: cacheManager,
+        },
+        {
+          provide: AuditLogService,
+          useValue: { log: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/backend/src/modules/savings/savings.service.ts
+++ b/backend/src/modules/savings/savings.service.ts
@@ -5,6 +5,7 @@ import {
   ConflictException,
   Logger,
   Inject,
+  Optional,
 } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
@@ -46,12 +47,16 @@ import { User } from '../user/entities/user.entity';
 import { SavingsService as BlockchainSavingsService } from '../blockchain/savings.service';
 import { PredictiveEvaluatorService } from './services/predictive-evaluator.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { SavingsProductVersionAudit } from './entities/savings-product-version-audit.entity';
 import { WaitlistService } from './waitlist.service';
 import { MilestoneService } from './services/milestone.service';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+} from '../../common/entities/audit-log.entity';
 
 export type SavingsGoalProgress = GoalProgressDto;
 
@@ -127,6 +132,7 @@ export class SavingsService {
     private readonly waitlistService: WaitlistService,
     private readonly configService: ConfigService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly auditLogService: AuditLogService,
     @Optional() private readonly eventEmitter?: EventEmitter2,
   ) {}
 
@@ -449,6 +455,8 @@ export class SavingsService {
     productId: string,
     amount: number,
     overrideLimits = false,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<UserSubscription> {
     const product = await this.findOneProduct(productId);
     await this.syncCapacityState(product);
@@ -538,6 +546,18 @@ export class SavingsService {
 
     // Record waitlist conversion if the user was on the waitlist
     await this.waitlistService.recordConversion(userId, product.id);
+
+    await this.auditLogService.log({
+      action: AuditAction.DEPOSIT,
+      resourceType: AuditResourceType.SAVINGS,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: savedSubscription.id,
+      description: `User subscribed to savings product ${product.name} with amount ${amount}`,
+      newValue: { productId, amount, subscriptionId: savedSubscription.id },
+      success: true,
+    });
 
     return savedSubscription;
   }
@@ -1060,6 +1080,8 @@ export class SavingsService {
     subscriptionId: string,
     amount: number,
     reason?: string,
+    correlationId?: string,
+    requestId?: string,
   ): Promise<WithdrawalRequest> {
     const subscription = await this.subscriptionRepository.findOne({
       where: { id: subscriptionId, userId },
@@ -1106,10 +1128,24 @@ export class SavingsService {
     const saved = await this.withdrawalRepository.save(withdrawalRequest);
 
     // Process withdrawal asynchronously
-    this.processWithdrawal(saved.id).catch((error) => {
-      this.logger.error(
-        `Failed to process withdrawal ${saved.id}: ${(error as Error).message}`,
-      );
+    this.processWithdrawal(saved.id, correlationId, requestId).catch(
+      (error) => {
+        this.logger.error(
+          `Failed to process withdrawal ${saved.id}: ${(error as Error).message}`,
+        );
+      },
+    );
+
+    await this.auditLogService.log({
+      action: AuditAction.WITHDRAW,
+      resourceType: AuditResourceType.WITHDRAWAL_REQUEST,
+      actor: userId,
+      correlationId,
+      requestId,
+      resourceId: saved.id,
+      description: `User requested withdrawal of ${amount} from subscription ${subscriptionId}${reason ? `: ${reason}` : ''}`,
+      newValue: { subscriptionId, amount, penalty, netAmount, reason },
+      success: true,
     });
 
     return saved;
@@ -1138,7 +1174,11 @@ export class SavingsService {
     return Number(penalty.toFixed(7));
   }
 
-  private async processWithdrawal(withdrawalId: string): Promise<void> {
+  private async processWithdrawal(
+    withdrawalId: string,
+    correlationId?: string,
+    requestId?: string,
+  ): Promise<void> {
     const withdrawal = await this.withdrawalRepository.findOne({
       where: { id: withdrawalId },
       relations: ['subscription', 'subscription.product'],
@@ -1210,6 +1250,23 @@ export class SavingsService {
       withdrawal.completedAt = new Date();
       await this.withdrawalRepository.save(withdrawal);
 
+      await this.auditLogService.log({
+        action: AuditAction.WITHDRAW,
+        resourceType: AuditResourceType.WITHDRAWAL_REQUEST,
+        actor: withdrawal.userId,
+        correlationId,
+        requestId,
+        resourceId: withdrawal.id,
+        description: `Withdrawal ${withdrawalId} processed successfully — net ${withdrawal.netAmount}`,
+        newValue: {
+          status: WithdrawalStatus.COMPLETED,
+          txHash: transaction.txHash,
+          netAmount: withdrawal.netAmount,
+          penalty: withdrawal.penalty,
+        },
+        success: true,
+      });
+
       // Emit event for notification
       this.eventEmitter?.emit('withdrawal.completed', {
         userId: withdrawal.userId,
@@ -1222,6 +1279,19 @@ export class SavingsService {
     } catch (error) {
       withdrawal.status = WithdrawalStatus.FAILED;
       await this.withdrawalRepository.save(withdrawal);
+
+      await this.auditLogService.log({
+        action: AuditAction.WITHDRAW,
+        resourceType: AuditResourceType.WITHDRAWAL_REQUEST,
+        actor: withdrawal.userId,
+        correlationId,
+        requestId,
+        resourceId: withdrawal.id,
+        description: `Withdrawal ${withdrawalId} failed: ${(error as Error).message}`,
+        errorMessage: (error as Error).message,
+        success: false,
+      });
+
       throw error;
     }
   }


### PR DESCRIPTION
Closes #1033

## Description

Implements structured audit logging for user-level actions (deposits, withdrawals, disputes, votes). Adds explicit `requestId` field alongside existing `correlationId` for full end-to-end tracing.

## Changes

### Tracing IDs
- Added `requestId` column to `AuditLog` entity with migration (`backend/src/migrations/1775300000002-AddRequestIdToAuditLogs.ts`)
- Updated `CorrelationIdMiddleware` to extract `requestId` from `X-Request-ID` header (or generate UUID) separately from `correlationId` from `X-Correlation-ID` header
- Added `@RequestId()` param decorator for controllers
- Updated `AuditLogService` to accept and persist `requestId`

### Audit Logging Coverage
- **Deposits** — already logged; now includes `requestId`
- **Withdrawals** — creation already logged; added logging for async processing completion and failure
- **Disputes** — submission already logged; added logging for lifecycle transitions (investigation start, resolution, close, escalation)
- **Governance** — votes already logged; added logging for proposal creation, queue, execute, cancel, and finalize

### Documentation
- Added **Audit Log Database Retention Policy** section to `LOGGING_IMPLEMENTATION.md` covering:
  - Configurable retention via `audit.retentionDays` (default 90)
  - `AdminAuditLogsService.cleanupOldLogs()` cleanup
  - Daily cron archival to local JSONL + S3 Glacier cold storage
  - Verification endpoints (`GET /admin/audit-logs/retention-policy` and `GET /admin/audit-logs/stats`)

### Fixes
- Added missing `AuditLogService` mock providers to `savings.service.spec.ts`, `disputes.service.spec.ts`, `governance.service.spec.ts`

## Acceptance Criteria
- ✅ User action events (deposits, withdrawals, disputes, votes) logged
- ✅ Includes `correlationId` and `requestId`
- ✅ Audit log retention policy documented
Branch: issue/1033-structured-audit-logging-user-actions