### PR TITLE
test: add saved query CRUD and RBAC isolation tests for transaction search

### DIFF
--- a/backend/src/modules/transactions/transactions.service.spec.ts
+++ b/backend/src/modules/transactions/transactions.service.spec.ts
@@ -244,4 +244,87 @@ describe('TransactionsService', () => {
       );
     });
   });
+
+  describe('createSavedSearch', () => {
+    it('should create a saved search for a user', async () => {
+      const userId = 'test-user-id';
+      const dto = { name: 'My Search', filters: { type: ['DEPOSIT'] }, isDefault: false };
+      const savedSearch = { id: '1', userId, ...dto, createdAt: new Date() };
+
+      mockSavedSearchRepository.create.mockReturnValue(savedSearch);
+      mockSavedSearchRepository.save.mockResolvedValue(savedSearch);
+      mockSavedSearchRepository.find.mockResolvedValue([]);
+
+      const result = await service.createSavedSearch(userId, dto as any);
+
+      expect(mockSavedSearchRepository.create).toHaveBeenCalled();
+      expect(mockSavedSearchRepository.save).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('listSavedSearches', () => {
+    it('should return saved searches for a user', async () => {
+      const userId = 'test-user-id';
+      const searches = [
+        { id: '1', userId, name: 'Search 1', filters: {}, isDefault: false, createdAt: new Date() },
+      ];
+
+      mockSavedSearchRepository.find.mockResolvedValue(searches);
+
+      const result = await service.listSavedSearches(userId);
+
+      expect(mockSavedSearchRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId } }),
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('should return empty array when no saved searches exist', async () => {
+      mockSavedSearchRepository.find.mockResolvedValue([]);
+      const result = await service.listSavedSearches('user-id');
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('updateSavedSearch', () => {
+    it('should update a saved search belonging to the user', async () => {
+      const userId = 'test-user-id';
+      const id = 'search-1';
+      const dto = { name: 'Updated Search' };
+      const existing = { id, userId, name: 'Old Search', filters: {}, isDefault: false };
+      const updated = { ...existing, ...dto };
+
+      mockSavedSearchRepository.findOne.mockResolvedValue(existing);
+      mockSavedSearchRepository.save.mockResolvedValue(updated);
+
+      const result = await service.updateSavedSearch(userId, id, dto as any);
+
+      expect(mockSavedSearchRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id, userId } }),
+      );
+      expect(result).toBeDefined();
+    });
+
+    it('should return error when saved search not found', async () => {
+      mockSavedSearchRepository.findOne.mockResolvedValue(null);
+      const result = await service.updateSavedSearch('user-id', 'bad-id', {} as any);
+      expect(result).toEqual(expect.objectContaining({ ok: false }));
+    });
+  });
+
+  describe('deleteSavedSearch', () => {
+    it('should delete a saved search belonging to the user', async () => {
+      const userId = 'test-user-id';
+      const id = 'search-1';
+      const existing = { id, userId, name: 'Search', filters: {}, isDefault: false };
+
+      mockSavedSearchRepository.findOne.mockResolvedValue(existing);
+      mockSavedSearchRepository.delete.mockResolvedValue({ affected: 1 });
+
+      await service.deleteSavedSearch(userId, id);
+
+      expect(mockSavedSearchRepository.delete).toHaveBeenCalledWith({ id, userId });
+    });
+  });
 });


### PR DESCRIPTION
closes
#1034 

## Changes
- `backend/src/modules/transactions/transactions.service.spec.ts`: Added comprehensive tests for saved query CRUD operations and RBAC user isolation

## Tests Added
- `createSavedSearch` — verifies saved search is created for a user
- `listSavedSearches` — verifies saved searches are returned for a user and empty array when none exist
- `updateSavedSearch` — verifies update works for owned searches and returns error when not found
- `deleteSavedSearch` — verifies deletion is scoped to the correct user

## Why
The saved query feature was implemented but lacked unit test coverage for CRUD operations and user isolation (RBAC).earch