### PR TITLE
feat: implement GDPR-friendly user data deletion workflow with audit …

### DIFF
--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -11,12 +11,17 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { UpdateSweepSettingsDto } from './dto/update-sweep-settings.dto';
 import { SweepSettingsDto } from './dto/sweep-settings.dto';
 import { UserProfileResponseDto } from './dto/user-profile-response.dto';
-
+import { AuditLogService } from '../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+} from '../../common/entities/audit-log.entity';
 @Injectable()
 export class UserService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   async findById(id: string) {
@@ -276,8 +281,36 @@ export class UserService {
 
   async remove(id: string) {
     const user = await this.findById(id);
+    const previousValue = { ...user };
 
-    await this.userRepository.remove(user);
+    const anonymizedEmail = `deleted-${user.id}@anonymized.local`;
+
+    await this.userRepository.update(id, {
+      email: anonymizedEmail,
+      name: 'Deleted User',
+      password: null,
+      publicKey: null,
+      walletAddress: null,
+      bio: '',
+      avatarUrl: null,
+      kycDocumentUrl: null,
+      kycStatus: 'NOT_SUBMITTED',
+      kycRejectionReason: null,
+      twoFactorEnabled: false,
+      twoFactorSecret: null,
+      twoFactorBackupCodes: null,
+      isActive: false,
+    });
+
+    await this.auditLogService.log({
+      action: AuditAction.DELETE,
+      resourceType: AuditResourceType.USER,
+      resourceId: id,
+      actor: id,
+      description: 'GDPR-friendly user data deletion and anonymization',
+      previousValue,
+      newValue: { isActive: false, email: anonymizedEmail },
+    });
 
     return { message: 'User deleted successfully' };
   }


### PR DESCRIPTION
## What was done
- Refactored the `remove` method in `UserService` to perform a GDPR-compliant soft-delete and anonymization instead of a hard TypeORM `.remove()`.
- Explicitly nullified or obfuscated Personal Identifiable Information (PII) fields (e.g., `email`, `name`, `publicKey`, `walletAddress`, `bio`, `kycDocumentUrl`).
- Set the user's `isActive` flag to `false`.
- Integrated the `AuditLogService` to capture the `DELETE` action on the `USER` resource, including the state changes (previous vs. new value) for compliance traceability.

## Why it was done
To comply with GDPR-like requirements (#1095) that mandate user data must be explicitly anonymized/deleted upon request. It also ensures an audit trail is maintained for security and compliance audits.

## How it was verified
- Verified that the TypeORM update correctly applies the anonymized fields (e.g. `deleted-<uuid>@anonymized.local`).
- Verified that the `AuditLogService` correctly logs the `AuditAction.DELETE` event without crashing the deletion process.

Closes #1095 