### PR TITLE
feat(referrals): add versioned referral.completed event contract and …

### DIFF
--- a/backend/src/modules/referrals/referral-events.listener.spec.ts
+++ b/backend/src/modules/referrals/referral-events.listener.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Notification } from '../notifications/entities/notification.entity';
+import { ReferralEventsListener } from './referral-events.listener';
+import { ReferralsService } from './referrals.service';
+import {
+  REFERRAL_COMPLETED_EVENT,
+  ReferralCompletedEventPayloadV1,
+} from './referral-events.types';
+
+describe('ReferralEventsListener', () => {
+  let listener: ReferralEventsListener;
+  let notificationRepository: Repository<Notification>;
+  let referralsService: ReferralsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralEventsListener,
+        {
+          provide: getRepositoryToken(Notification),
+          useValue: {
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: ReferralsService,
+          useValue: {
+            distributeRewards: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    listener = module.get<ReferralEventsListener>(ReferralEventsListener);
+    notificationRepository = module.get<Repository<Notification>>(
+      getRepositoryToken(Notification),
+    );
+    referralsService = module.get<ReferralsService>(ReferralsService);
+  });
+
+  it('should handle version 1 referral.completed payload', async () => {
+    const payload: ReferralCompletedEventPayloadV1 = {
+      eventType: REFERRAL_COMPLETED_EVENT,
+      schemaVersion: 1,
+      referralId: 'referral-1',
+      referrerId: 'user-1',
+      refereeId: 'user-2',
+      campaignId: 'campaign-1',
+      completedAt: new Date().toISOString(),
+    };
+
+    await listener.handleReferralCompleted(payload);
+
+    expect(notificationRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        type: expect.anything(),
+        metadata: { referralId: 'referral-1' },
+      }),
+    );
+    expect(referralsService.distributeRewards).toHaveBeenCalledWith(
+      'referral-1',
+    );
+  });
+
+  it('should handle legacy referral.completed payload without version fields', async () => {
+    const legacyPayload = {
+      referralId: 'referral-2',
+      referrerId: 'user-3',
+      refereeId: 'user-4',
+      campaignId: null,
+    };
+
+    await listener.handleReferralCompleted(legacyPayload);
+
+    expect(notificationRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-3',
+        metadata: { referralId: 'referral-2' },
+      }),
+    );
+    expect(referralsService.distributeRewards).toHaveBeenCalledWith(
+      'referral-2',
+    );
+  });
+});

--- a/backend/src/modules/referrals/referral-events.listener.ts
+++ b/backend/src/modules/referrals/referral-events.listener.ts
@@ -7,6 +7,11 @@ import {
   NotificationType,
 } from '../notifications/entities/notification.entity';
 import { ReferralsService } from './referrals.service';
+import {
+  REFERRAL_COMPLETED_EVENT,
+  ReferralCompletedEventPayload,
+  normalizeReferralCompletedEvent,
+} from './referral-events.types';
 
 @Injectable()
 export class ReferralEventsListener {
@@ -46,26 +51,24 @@ export class ReferralEventsListener {
     }
   }
 
-  @OnEvent('referral.completed')
-  async handleReferralCompleted(payload: {
-    referralId: string;
-    referrerId: string;
-    refereeId: string;
-  }) {
-    this.logger.log(`Referral ${payload.referralId} completed`);
+  @OnEvent(REFERRAL_COMPLETED_EVENT)
+  async handleReferralCompleted(payload: ReferralCompletedEventPayload) {
+    const normalizedPayload = normalizeReferralCompletedEvent(payload);
+
+    this.logger.log(`Referral ${normalizedPayload.referralId} completed`);
 
     // Notify referrer
     await this.notificationRepository.save({
-      userId: payload.referrerId,
+      userId: normalizedPayload.referrerId,
       type: NotificationType.REFERRAL_COMPLETED,
       title: 'Referral Completed!',
       message:
         'Your referral has completed their first deposit. Rewards will be distributed soon.',
-      metadata: { referralId: payload.referralId },
+      metadata: { referralId: normalizedPayload.referralId },
     });
 
     // Automatically distribute rewards
-    await this.referralsService.distributeRewards(payload.referralId);
+    await this.referralsService.distributeRewards(normalizedPayload.referralId);
   }
 
   @OnEvent('referral.reward.distribute')

--- a/backend/src/modules/referrals/referral-events.types.ts
+++ b/backend/src/modules/referrals/referral-events.types.ts
@@ -1,0 +1,50 @@
+export const REFERRAL_COMPLETED_EVENT = 'referral.completed' as const;
+
+export type ReferralCompletedEventName = typeof REFERRAL_COMPLETED_EVENT;
+
+export interface ReferralCompletedEventPayloadV1 {
+  eventType: ReferralCompletedEventName;
+  schemaVersion: 1;
+  referralId: string;
+  referrerId: string;
+  refereeId: string;
+  campaignId?: string | null;
+  completedAt?: string;
+}
+
+export type ReferralCompletedEventPayloadV0 = Omit<
+  ReferralCompletedEventPayloadV1,
+  'eventType' | 'schemaVersion'
+>;
+
+export type ReferralCompletedEventPayload =
+  | ReferralCompletedEventPayloadV1
+  | ReferralCompletedEventPayloadV0;
+
+export function isReferralCompletedEventV1(
+  payload: unknown,
+): payload is ReferralCompletedEventPayloadV1 {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    (payload as any).eventType === REFERRAL_COMPLETED_EVENT &&
+    (payload as any).schemaVersion === 1
+  );
+}
+
+export function normalizeReferralCompletedEvent(
+  payload: ReferralCompletedEventPayload,
+): ReferralCompletedEventPayloadV1 {
+  if (isReferralCompletedEventV1(payload)) {
+    return payload;
+  }
+
+  return {
+    eventType: REFERRAL_COMPLETED_EVENT,
+    schemaVersion: 1,
+    referralId: (payload as any).referralId,
+    referrerId: (payload as any).referrerId,
+    refereeId: (payload as any).refereeId,
+    campaignId: (payload as any).campaignId ?? null,
+  };
+}

--- a/backend/src/modules/referrals/referrals.service.spec.ts
+++ b/backend/src/modules/referrals/referrals.service.spec.ts
@@ -19,6 +19,7 @@ describe('ReferralsService', () => {
   let referralRepository: Repository<Referral>;
   let campaignRepository: Repository<ReferralCampaign>;
   let userRepository: Repository<User>;
+  let processedReferralEventRepository: Repository<ProcessedReferralEvent>;
   let eventEmitter: EventEmitter2;
   let fraudDetectionService: jest.Mocked<ReferralFraudDetectionService>;
 
@@ -106,6 +107,9 @@ describe('ReferralsService', () => {
     campaignRepository = module.get<Repository<ReferralCampaign>>(
       getRepositoryToken(ReferralCampaign),
     );
+    processedReferralEventRepository = module.get<
+      Repository<ProcessedReferralEvent>
+    >(getRepositoryToken(ProcessedReferralEvent));
     userRepository = module.get<Repository<User>>(getRepositoryToken(User));
     eventEmitter = module.get<EventEmitter2>(EventEmitter2);
   });
@@ -196,6 +200,44 @@ describe('ReferralsService', () => {
       await expect(
         service.applyReferralCode('ABC12345', 'user-1'),
       ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('checkAndCompleteReferral', () => {
+    it('should emit a versioned referral.completed event when a referral is completed', async () => {
+      const referral = {
+        ...mockReferral,
+        refereeId: 'user-2',
+        status: ReferralStatus.PENDING,
+        referrerId: 'user-1',
+        campaignId: null,
+      };
+
+      jest
+        .spyOn(processedReferralEventRepository, 'findOne')
+        .mockResolvedValue(null);
+      jest
+        .spyOn(referralRepository, 'findOne')
+        .mockResolvedValue(referral as any);
+      jest.spyOn(referralRepository, 'save').mockResolvedValue({
+        ...referral,
+        status: ReferralStatus.COMPLETED,
+        completedAt: new Date(),
+      } as any);
+      const eventSpy = jest.spyOn(eventEmitter, 'emit');
+
+      await service.checkAndCompleteReferral('user-2', '5');
+
+      expect(eventSpy).toHaveBeenCalledWith(
+        'referral.completed',
+        expect.objectContaining({
+          eventType: 'referral.completed',
+          schemaVersion: 1,
+          referralId: 'referral-1',
+          referrerId: 'user-1',
+          refereeId: 'user-2',
+        }),
+      );
     });
   });
 

--- a/backend/src/modules/referrals/referrals.service.ts
+++ b/backend/src/modules/referrals/referrals.service.ts
@@ -18,6 +18,10 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomBytes } from 'crypto';
 import { ReferralFraudDetectionService } from './referral-fraud-detection.service';
 import { ReferralFraudEvaluationContext } from './referral-fraud.types';
+import {
+  REFERRAL_COMPLETED_EVENT,
+  ReferralCompletedEventPayloadV1,
+} from './referral-events.types';
 
 @Injectable()
 export class ReferralsService {
@@ -300,13 +304,18 @@ export class ReferralsService {
       { depositAmount },
     );
 
-    // Emit event for reward distribution
-    this.eventEmitter.emit('referral.completed', {
+    // Emit versioned referral.completed event for backward compatible consumers
+    const completedEvent: ReferralCompletedEventPayloadV1 = {
+      eventType: REFERRAL_COMPLETED_EVENT,
+      schemaVersion: 1,
       referralId: referral.id,
       referrerId: referral.referrerId,
-      refereeId: referral.refereeId,
+      refereeId: referral.refereeId!,
       campaignId: referral.campaignId,
-    });
+      completedAt: referral.completedAt?.toISOString(),
+    };
+
+    this.eventEmitter.emit(REFERRAL_COMPLETED_EVENT, completedEvent);
 
     this.logger.log(`Referral ${referral.id} completed`);
   }


### PR DESCRIPTION
## feat(referrals): add versioned referral.completed event contract and backward-compatible listener handling

**Description:**
- Added versioned referral event contract with `eventType` and `schemaVersion`
- Implemented normalization for legacy `referral.completed` payloads
- Updated referral service to emit `referral.completed` in versioned format
- Added listener compatibility so both v1 and legacy payloads are handled correctly
- Added tests validating:
  - versioned event listener handling
  - legacy payload backward compatibility
  - versioned event emission from referral completion

Closes: #1130 