### PR TITLE
feat(admin): add idempotency key usage and conflict monitoring endpoint

### DIFF
--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -2,6 +2,7 @@ import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PiiEncryptionService } from './services/pii-encryption.service';
 import { RateLimitMonitorService } from './services/rate-limit-monitor.service';
+import { IdempotencyMonitorService } from './services/idempotency-monitor.service';
 import { SecretsConfigService } from './services/secrets-config.service';
 import { IdempotencyService } from './services/idempotency.service';
 import { IdempotencyCleanupService } from './services/idempotency-cleanup.service';
@@ -23,6 +24,7 @@ import { DistributedLockModule } from './distributed-lock/distributed-lock.modul
   imports: [CacheModule, TypeOrmModule.forFeature([AuditLog, Tenant])],
   providers: [
     RateLimitMonitorService,
+    IdempotencyMonitorService,
     PiiEncryptionService,
     SecretsConfigService,
     IdempotencyService,
@@ -38,6 +40,7 @@ import { DistributedLockModule } from './distributed-lock/distributed-lock.modul
   ],
   exports: [
     RateLimitMonitorService,
+    IdempotencyMonitorService,
     PiiEncryptionService,
     SecretsConfigService,
     IdempotencyService,

--- a/backend/src/common/interceptors/idempotency.interceptor.ts
+++ b/backend/src/common/interceptors/idempotency.interceptor.ts
@@ -6,6 +6,7 @@ import {
   ConflictException,
   Logger,
   Inject,
+  Optional,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Observable, of, throwError } from 'rxjs';
@@ -19,6 +20,7 @@ import {
   IdempotencyOptions,
 } from '../decorators/idempotent.decorator';
 import { ErrorCode } from '../enums/error-code.enum';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 interface StoredIdempotencyRecord {
   payloadHash: string;
@@ -30,6 +32,17 @@ interface StoredIdempotencyRecord {
 const LOCK_SUFFIX = ':lock';
 const LOCK_TTL_MS = 30_000;
 
+/**
+ * Infers a related entity type from the route path for admin observability.
+ * e.g. /savings/123 → "savings", /transactions/abc → "transactions"
+ */
+function inferEntityType(path: string): string | undefined {
+  const segments = path.split('/').filter(Boolean);
+  // Return the first meaningful path segment (skipping 'api', 'v1', etc.)
+  const skipSegments = new Set(['api', 'v1', 'v2', 'v3']);
+  return segments.find((s) => !skipSegments.has(s) && !/^\d+$/.test(s));
+}
+
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
   private readonly logger = new Logger(IdempotencyInterceptor.name);
@@ -37,6 +50,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
   constructor(
     private readonly reflector: Reflector,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
+    @Optional() private readonly eventEmitter?: EventEmitter2,
   ) {}
 
   async intercept(
@@ -69,6 +83,15 @@ export class IdempotencyInterceptor implements NestInterceptor {
 
     if (existing) {
       if (existing.payloadHash !== payloadHash) {
+        // Conflict: same key, different payload
+        this.emitConflict({
+          idempotencyKey,
+          requestFingerprintHash: payloadHash,
+          method: request.method,
+          path: request.path,
+          conflictType: 'payload_mismatch',
+        });
+
         return throwError(
           () =>
             new ConflictException({
@@ -82,6 +105,14 @@ export class IdempotencyInterceptor implements NestInterceptor {
       this.logger.debug(
         `Idempotency cache hit for key=${idempotencyKey} on ${request.method} ${request.path}`,
       );
+
+      // Emit replay event for monitoring
+      this.eventEmitter?.emit('idempotency.replay', {
+        key: idempotencyKey,
+        method: request.method,
+        path: request.path,
+      });
+
       response.setHeader('Idempotency-Replay', 'true');
       response.status(existing.statusCode);
       return of(existing.body);
@@ -91,6 +122,15 @@ export class IdempotencyInterceptor implements NestInterceptor {
     const lockAcquired = await this.tryAcquireLock(lockKey);
 
     if (!lockAcquired) {
+      // Conflict: concurrent processing with the same key
+      this.emitConflict({
+        idempotencyKey,
+        requestFingerprintHash: payloadHash,
+        method: request.method,
+        path: request.path,
+        conflictType: 'concurrent_processing',
+      });
+
       return throwError(
         () =>
           new ConflictException({
@@ -102,6 +142,13 @@ export class IdempotencyInterceptor implements NestInterceptor {
     }
 
     const ttlMs = (options.ttlSeconds ?? 86400) * 1000;
+
+    // Emit first_use event for monitoring
+    this.eventEmitter?.emit('idempotency.first_use', {
+      key: idempotencyKey,
+      method: request.method,
+      path: request.path,
+    });
 
     return next.handle().pipe(
       tap(async (body) => {
@@ -142,5 +189,23 @@ export class IdempotencyInterceptor implements NestInterceptor {
     } catch {
       // Lock cleanup is best-effort
     }
+  }
+
+  private emitConflict(params: {
+    idempotencyKey: string;
+    requestFingerprintHash: string;
+    method: string;
+    path: string;
+    conflictType: 'payload_mismatch' | 'concurrent_processing';
+  }): void {
+    this.eventEmitter?.emit('idempotency.conflict', {
+      idempotencyKey: params.idempotencyKey,
+      requestFingerprintHash: params.requestFingerprintHash,
+      method: params.method,
+      path: params.path,
+      conflictType: params.conflictType,
+      timestamp: new Date().toISOString(),
+      relatedEntityType: inferEntityType(params.path),
+    });
   }
 }

--- a/backend/src/common/services/idempotency-monitor.service.spec.ts
+++ b/backend/src/common/services/idempotency-monitor.service.spec.ts
@@ -1,0 +1,309 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  IdempotencyMonitorService,
+  IdempotencyConflictEvent,
+} from './idempotency-monitor.service';
+
+describe('IdempotencyMonitorService', () => {
+  let service: IdempotencyMonitorService;
+
+  const makeConflict = (
+    overrides?: Partial<IdempotencyConflictEvent>,
+  ): IdempotencyConflictEvent => ({
+    idempotencyKey: 'key-1',
+    requestFingerprintHash: 'hash-abc',
+    method: 'POST',
+    path: '/savings/deposit',
+    conflictType: 'payload_mismatch',
+    timestamp: new Date().toISOString(),
+    relatedEntityType: 'savings',
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IdempotencyMonitorService,
+        {
+          provide: EventEmitter2,
+          useValue: { emit: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<IdempotencyMonitorService>(IdempotencyMonitorService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // handleConflict / getRecentConflicts
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('handleConflict', () => {
+    it('stores a conflict and returns it', () => {
+      service.handleConflict(makeConflict());
+      const conflicts = service.getRecentConflicts();
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0].idempotencyKey).toBe('key-1');
+    });
+
+    it('returns conflicts newest first', () => {
+      service.handleConflict(makeConflict({ idempotencyKey: 'first' }));
+      service.handleConflict(makeConflict({ idempotencyKey: 'second' }));
+
+      const conflicts = service.getRecentConflicts(10);
+      expect(conflicts[0].idempotencyKey).toBe('second');
+      expect(conflicts[1].idempotencyKey).toBe('first');
+    });
+
+    it('caps at MAX_CONFLICTS (1000) using circular buffer', () => {
+      for (let i = 0; i < 1050; i++) {
+        service.handleConflict(makeConflict({ idempotencyKey: `key-${i}` }));
+      }
+      // Buffer should not exceed 1000
+      const all = service.getRecentConflicts(2000);
+      expect(all.length).toBeLessThanOrEqual(1000);
+    });
+
+    it('evicts the oldest entry when the buffer is full', () => {
+      // Fill to capacity
+      for (let i = 0; i < 1000; i++) {
+        service.handleConflict(
+          makeConflict({ idempotencyKey: `old-key-${i}` }),
+        );
+      }
+      // Add one more
+      service.handleConflict(makeConflict({ idempotencyKey: 'newest' }));
+
+      const all = service.getRecentConflicts(2000);
+      // Newest should be present
+      expect(all.some((c) => c.idempotencyKey === 'newest')).toBe(true);
+      // The very first entry should have been evicted
+      expect(all.some((c) => c.idempotencyKey === 'old-key-0')).toBe(false);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // getRecentConflicts – filtering
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getRecentConflicts filtering', () => {
+    beforeEach(() => {
+      service.handleConflict(
+        makeConflict({
+          conflictType: 'payload_mismatch',
+          path: '/savings/deposit',
+        }),
+      );
+      service.handleConflict(
+        makeConflict({
+          conflictType: 'concurrent_processing',
+          path: '/transactions/send',
+        }),
+      );
+      service.handleConflict(
+        makeConflict({
+          conflictType: 'payload_mismatch',
+          path: '/transactions/refund',
+        }),
+      );
+    });
+
+    it('filters by conflictType', () => {
+      const mismatches = service.getRecentConflicts(10, 'payload_mismatch');
+      expect(mismatches).toHaveLength(2);
+      expect(
+        mismatches.every((c) => c.conflictType === 'payload_mismatch'),
+      ).toBe(true);
+    });
+
+    it('filters by path (partial match)', () => {
+      const tx = service.getRecentConflicts(10, undefined, '/transactions');
+      expect(tx).toHaveLength(2);
+    });
+
+    it('applies both conflictType and path filters', () => {
+      const result = service.getRecentConflicts(
+        10,
+        'payload_mismatch',
+        '/transactions',
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].path).toBe('/transactions/refund');
+    });
+
+    it('respects the limit parameter', () => {
+      const result = service.getRecentConflicts(1);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // getConflictSummary
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getConflictSummary', () => {
+    it('returns zero counts when there are no conflicts', () => {
+      const summary = service.getConflictSummary();
+      expect(summary.total).toBe(0);
+      expect(summary.last24h).toBe(0);
+      expect(summary.last1h).toBe(0);
+      expect(summary.topConflictingKeys).toHaveLength(0);
+    });
+
+    it('counts conflicts by type', () => {
+      service.handleConflict(
+        makeConflict({ conflictType: 'payload_mismatch' }),
+      );
+      service.handleConflict(
+        makeConflict({ conflictType: 'payload_mismatch' }),
+      );
+      service.handleConflict(
+        makeConflict({ conflictType: 'concurrent_processing' }),
+      );
+
+      const summary = service.getConflictSummary();
+      expect(summary.byConflictType['payload_mismatch']).toBe(2);
+      expect(summary.byConflictType['concurrent_processing']).toBe(1);
+    });
+
+    it('counts conflicts by route', () => {
+      service.handleConflict(
+        makeConflict({ method: 'POST', path: '/savings/deposit' }),
+      );
+      service.handleConflict(
+        makeConflict({ method: 'POST', path: '/savings/deposit' }),
+      );
+      service.handleConflict(
+        makeConflict({ method: 'POST', path: '/transactions/send' }),
+      );
+
+      const summary = service.getConflictSummary();
+      expect(summary.byRoute['POST /savings/deposit']).toBe(2);
+      expect(summary.byRoute['POST /transactions/send']).toBe(1);
+    });
+
+    it('identifies top conflicting keys', () => {
+      for (let i = 0; i < 5; i++) {
+        service.handleConflict(makeConflict({ idempotencyKey: 'top-key' }));
+      }
+      service.handleConflict(makeConflict({ idempotencyKey: 'one-time' }));
+
+      const summary = service.getConflictSummary();
+      expect(summary.topConflictingKeys[0].idempotencyKey).toBe('top-key');
+      expect(summary.topConflictingKeys[0].count).toBe(5);
+    });
+
+    it('includes total regardless of timestamp', () => {
+      service.handleConflict(makeConflict());
+      service.handleConflict(makeConflict());
+      const summary = service.getConflictSummary();
+      expect(summary.total).toBe(2);
+    });
+
+    it('has correct shape', () => {
+      const summary = service.getConflictSummary();
+      expect(summary).toHaveProperty('total');
+      expect(summary).toHaveProperty('last24h');
+      expect(summary).toHaveProperty('last1h');
+      expect(summary).toHaveProperty('byConflictType');
+      expect(summary).toHaveProperty('byRoute');
+      expect(summary).toHaveProperty('topConflictingKeys');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // handleReplay / handleFirstUse / getKeyUsage
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('handleFirstUse and handleReplay', () => {
+    it('records first use', () => {
+      service.handleFirstUse({ key: 'k1', method: 'POST', path: '/savings' });
+      const usage = service.getKeyUsage();
+      expect(usage).toHaveLength(1);
+      expect(usage[0].idempotencyKey).toBe('k1');
+      expect(usage[0].replayCount).toBe(0);
+    });
+
+    it('increments replay count on subsequent calls', () => {
+      service.handleFirstUse({ key: 'k2', method: 'POST', path: '/savings' });
+      service.handleReplay({ key: 'k2', method: 'POST', path: '/savings' });
+      service.handleReplay({ key: 'k2', method: 'POST', path: '/savings' });
+
+      const usage = service.getKeyUsage();
+      const record = usage.find((r) => r.idempotencyKey === 'k2')!;
+      expect(record.replayCount).toBe(2);
+    });
+
+    it('creates a new usage record when handleReplay is called for an unknown key', () => {
+      service.handleReplay({ key: 'k3', method: 'GET', path: '/transactions' });
+      const usage = service.getKeyUsage();
+      const record = usage.find((r) => r.idempotencyKey === 'k3');
+      expect(record).toBeDefined();
+      expect(record!.replayCount).toBe(1);
+    });
+
+    it('ignores duplicate handleFirstUse calls for the same key', () => {
+      service.handleFirstUse({ key: 'k4', method: 'POST', path: '/savings' });
+      service.handleFirstUse({ key: 'k4', method: 'POST', path: '/savings' });
+      const usage = service.getKeyUsage();
+      expect(usage.filter((r) => r.idempotencyKey === 'k4')).toHaveLength(1);
+    });
+
+    it('sorts results by lastSeenAt descending (most recently replayed first)', () => {
+      // 'older-sort' is registered and never replayed
+      service.handleFirstUse({ key: 'older-sort', method: 'POST', path: '/a' });
+      // 'newer-sort' is registered and then replayed — its lastSeenAt is updated
+      service.handleFirstUse({ key: 'newer-sort', method: 'POST', path: '/b' });
+      service.handleReplay({ key: 'newer-sort', method: 'POST', path: '/b' });
+
+      const usage = service.getKeyUsage();
+      // Both entries must be present
+      const newerRecord = usage.find((r) => r.idempotencyKey === 'newer-sort');
+      const olderRecord = usage.find((r) => r.idempotencyKey === 'older-sort');
+      expect(newerRecord).toBeDefined();
+      expect(olderRecord).toBeDefined();
+
+      // 'newer-sort' must have a later or equal lastSeenAt compared to 'older-sort'
+      expect(
+        new Date(newerRecord!.lastSeenAt).getTime(),
+      ).toBeGreaterThanOrEqual(new Date(olderRecord!.lastSeenAt).getTime());
+
+      // 'newer-sort' should have replayCount > 0, confirming it was updated last
+      expect(newerRecord!.replayCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getKeyUsage filtering', () => {
+    beforeEach(() => {
+      service.handleFirstUse({
+        key: 'k1',
+        method: 'POST',
+        path: '/savings/deposit',
+      });
+      service.handleFirstUse({
+        key: 'k2',
+        method: 'POST',
+        path: '/transactions/send',
+      });
+    });
+
+    it('filters by path (partial match)', () => {
+      const savings = service.getKeyUsage(10, '/savings');
+      expect(savings).toHaveLength(1);
+      expect(savings[0].idempotencyKey).toBe('k1');
+    });
+
+    it('returns all records when no path filter is given', () => {
+      expect(service.getKeyUsage(10)).toHaveLength(2);
+    });
+
+    it('respects the limit parameter', () => {
+      expect(service.getKeyUsage(1)).toHaveLength(1);
+    });
+  });
+});

--- a/backend/src/common/services/idempotency-monitor.service.ts
+++ b/backend/src/common/services/idempotency-monitor.service.ts
@@ -1,0 +1,205 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+export interface IdempotencyConflictEvent {
+  /** The idempotency key submitted by the client (never the payload) */
+  idempotencyKey: string;
+  /** SHA-256 fingerprint of the incoming request body */
+  requestFingerprintHash: string;
+  /** HTTP method of the conflicting request */
+  method: string;
+  /** Route path of the conflicting request */
+  path: string;
+  /** The type of conflict that occurred */
+  conflictType: 'payload_mismatch' | 'concurrent_processing';
+  /** ISO timestamp when the conflict was detected */
+  timestamp: string;
+  /** Related entity type inferred from the route, if determinable */
+  relatedEntityType?: string;
+}
+
+export interface IdempotencyUsageRecord {
+  /** The idempotency key submitted by the client */
+  idempotencyKey: string;
+  /** HTTP method */
+  method: string;
+  /** Route path */
+  path: string;
+  /** ISO timestamp of the first use */
+  firstSeenAt: string;
+  /** ISO timestamp of the last use / replay */
+  lastSeenAt: string;
+  /** Number of replay (cache-hit) requests for this key */
+  replayCount: number;
+}
+
+@Injectable()
+export class IdempotencyMonitorService {
+  private readonly logger = new Logger(IdempotencyMonitorService.name);
+
+  /** Circular buffer for conflicts – max 1 000 entries */
+  private readonly conflicts: IdempotencyConflictEvent[] = [];
+  private readonly MAX_CONFLICTS = 1_000;
+
+  /** Circular buffer for recent key usage – max 5 000 entries */
+  private readonly usageMap = new Map<string, IdempotencyUsageRecord>();
+  private readonly MAX_USAGE_KEYS = 5_000;
+
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Event listeners (called by IdempotencyInterceptor)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  @OnEvent('idempotency.conflict')
+  handleConflict(event: IdempotencyConflictEvent): void {
+    if (this.conflicts.length >= this.MAX_CONFLICTS) {
+      this.conflicts.shift();
+    }
+    this.conflicts.push(event);
+    this.logger.debug(
+      `Idempotency conflict recorded: key=${event.idempotencyKey} type=${event.conflictType} on ${event.method} ${event.path}`,
+    );
+  }
+
+  @OnEvent('idempotency.replay')
+  handleReplay(record: { key: string; method: string; path: string }): void {
+    const existing = this.usageMap.get(record.key);
+    if (existing) {
+      existing.lastSeenAt = new Date().toISOString();
+      existing.replayCount += 1;
+    } else {
+      this.evictOldestUsageIfNeeded();
+      this.usageMap.set(record.key, {
+        idempotencyKey: record.key,
+        method: record.method,
+        path: record.path,
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        replayCount: 1,
+      });
+    }
+  }
+
+  /** Called on first successful processing of a new idempotency key */
+  @OnEvent('idempotency.first_use')
+  handleFirstUse(record: { key: string; method: string; path: string }): void {
+    if (this.usageMap.has(record.key)) return;
+    this.evictOldestUsageIfNeeded();
+    this.usageMap.set(record.key, {
+      idempotencyKey: record.key,
+      method: record.method,
+      path: record.path,
+      firstSeenAt: new Date().toISOString(),
+      lastSeenAt: new Date().toISOString(),
+      replayCount: 0,
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Query methods (used by admin controller)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns the most recent conflicts, newest first.
+   * Optionally filtered by conflictType or route path.
+   */
+  getRecentConflicts(
+    limit = 50,
+    conflictType?: 'payload_mismatch' | 'concurrent_processing',
+    path?: string,
+  ): IdempotencyConflictEvent[] {
+    let results = [...this.conflicts].reverse();
+
+    if (conflictType) {
+      results = results.filter((c) => c.conflictType === conflictType);
+    }
+    if (path) {
+      results = results.filter((c) => c.path.includes(path));
+    }
+
+    return results.slice(0, limit);
+  }
+
+  /** Summary stats across all tracked conflicts */
+  getConflictSummary(): {
+    total: number;
+    last24h: number;
+    last1h: number;
+    byConflictType: Record<string, number>;
+    byRoute: Record<string, number>;
+    topConflictingKeys: { idempotencyKey: string; count: number }[];
+  } {
+    const now = Date.now();
+    const last24hCutoff = now - 24 * 60 * 60 * 1_000;
+    const last1hCutoff = now - 60 * 60 * 1_000;
+
+    const last24h = this.conflicts.filter(
+      (c) => new Date(c.timestamp).getTime() >= last24hCutoff,
+    );
+    const last1h = this.conflicts.filter(
+      (c) => new Date(c.timestamp).getTime() >= last1hCutoff,
+    );
+
+    const byConflictType: Record<string, number> = {};
+    const byRoute: Record<string, number> = {};
+    const keyCounts: Record<string, number> = {};
+
+    for (const c of last24h) {
+      byConflictType[c.conflictType] =
+        (byConflictType[c.conflictType] || 0) + 1;
+
+      const routeKey = `${c.method} ${c.path}`;
+      byRoute[routeKey] = (byRoute[routeKey] || 0) + 1;
+
+      keyCounts[c.idempotencyKey] = (keyCounts[c.idempotencyKey] || 0) + 1;
+    }
+
+    const topConflictingKeys = Object.entries(keyCounts)
+      .map(([idempotencyKey, count]) => ({ idempotencyKey, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    return {
+      total: this.conflicts.length,
+      last24h: last24h.length,
+      last1h: last1h.length,
+      byConflictType,
+      byRoute,
+      topConflictingKeys,
+    };
+  }
+
+  /**
+   * Returns recent key usage records, sorted by lastSeenAt descending.
+   */
+  getKeyUsage(limit = 50, path?: string): IdempotencyUsageRecord[] {
+    let records = Array.from(this.usageMap.values());
+
+    if (path) {
+      records = records.filter((r) => r.path.includes(path));
+    }
+
+    return records
+      .sort(
+        (a, b) =>
+          new Date(b.lastSeenAt).getTime() - new Date(a.lastSeenAt).getTime(),
+      )
+      .slice(0, limit);
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Internal helpers
+  // ──────────────────────────────────────────────────────────────────────────
+
+  private evictOldestUsageIfNeeded(): void {
+    if (this.usageMap.size >= this.MAX_USAGE_KEYS) {
+      // Map preserves insertion order; delete the first (oldest) entry
+      const firstKey = this.usageMap.keys().next().value;
+      if (firstKey !== undefined) {
+        this.usageMap.delete(firstKey);
+      }
+    }
+  }
+}

--- a/backend/src/modules/admin/admin-idempotency.controller.spec.ts
+++ b/backend/src/modules/admin/admin-idempotency.controller.spec.ts
@@ -1,0 +1,182 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminIdempotencyController } from './admin-idempotency.controller';
+import { IdempotencyMonitorService } from '../../common/services/idempotency-monitor.service';
+import {
+  IdempotencyConflictQueryDto,
+  IdempotencyUsageQueryDto,
+} from './dto/admin-idempotency.dto';
+
+describe('AdminIdempotencyController', () => {
+  let controller: AdminIdempotencyController;
+  let monitorService: jest.Mocked<IdempotencyMonitorService>;
+
+  const mockSummary = {
+    total: 10,
+    last24h: 5,
+    last1h: 1,
+    byConflictType: { payload_mismatch: 4, concurrent_processing: 1 },
+    byRoute: { 'POST /savings/deposit': 3 },
+    topConflictingKeys: [{ idempotencyKey: 'top-key', count: 3 }],
+  };
+
+  const mockConflicts = [
+    {
+      idempotencyKey: 'key-1',
+      requestFingerprintHash: 'sha256abc',
+      method: 'POST',
+      path: '/savings/deposit',
+      conflictType: 'payload_mismatch' as const,
+      timestamp: '2026-06-30T02:00:00.000Z',
+      relatedEntityType: 'savings',
+    },
+  ];
+
+  const mockUsage = [
+    {
+      idempotencyKey: 'key-1',
+      method: 'POST',
+      path: '/savings/deposit',
+      firstSeenAt: '2026-06-30T01:55:00.000Z',
+      lastSeenAt: '2026-06-30T02:00:00.000Z',
+      replayCount: 2,
+    },
+  ];
+
+  beforeEach(async () => {
+    monitorService = {
+      getConflictSummary: jest.fn().mockReturnValue(mockSummary),
+      getRecentConflicts: jest.fn().mockReturnValue(mockConflicts),
+      getKeyUsage: jest.fn().mockReturnValue(mockUsage),
+      handleConflict: jest.fn(),
+      handleReplay: jest.fn(),
+      handleFirstUse: jest.fn(),
+    } as unknown as jest.Mocked<IdempotencyMonitorService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminIdempotencyController],
+      providers: [
+        {
+          provide: IdempotencyMonitorService,
+          useValue: monitorService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AdminIdempotencyController>(
+      AdminIdempotencyController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GET /admin/idempotency/conflicts/summary
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getConflictSummary', () => {
+    it('calls getConflictSummary on the monitor service', () => {
+      const result = controller.getConflictSummary();
+      expect(monitorService.getConflictSummary).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockSummary);
+    });
+
+    it('returns an object with the expected shape', () => {
+      const result = controller.getConflictSummary();
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('last24h');
+      expect(result).toHaveProperty('last1h');
+      expect(result).toHaveProperty('byConflictType');
+      expect(result).toHaveProperty('byRoute');
+      expect(result).toHaveProperty('topConflictingKeys');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GET /admin/idempotency/conflicts
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getRecentConflicts', () => {
+    it('calls getRecentConflicts with defaults when no query params are given', () => {
+      const query: IdempotencyConflictQueryDto = {};
+      controller.getRecentConflicts(query);
+      expect(monitorService.getRecentConflicts).toHaveBeenCalledWith(
+        50,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('passes limit, conflictType and path from the query DTO', () => {
+      const query: IdempotencyConflictQueryDto = {
+        limit: 10,
+        conflictType: 'payload_mismatch',
+        path: '/savings',
+      };
+      controller.getRecentConflicts(query);
+      expect(monitorService.getRecentConflicts).toHaveBeenCalledWith(
+        10,
+        'payload_mismatch',
+        '/savings',
+      );
+    });
+
+    it('returns the data from the monitor service', () => {
+      const result = controller.getRecentConflicts({});
+      expect(result).toEqual(mockConflicts);
+    });
+
+    it('does not expose sensitive payload data in the response', () => {
+      const result = controller.getRecentConflicts({});
+      for (const item of result) {
+        // Only fingerprint hash must be present, not any raw body field
+        expect(item).toHaveProperty('requestFingerprintHash');
+        expect(item).not.toHaveProperty('body');
+        expect(item).not.toHaveProperty('payload');
+      }
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GET /admin/idempotency/usage
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getKeyUsage', () => {
+    it('calls getKeyUsage with defaults when no query params are given', () => {
+      const query: IdempotencyUsageQueryDto = {};
+      controller.getKeyUsage(query);
+      expect(monitorService.getKeyUsage).toHaveBeenCalledWith(50, undefined);
+    });
+
+    it('passes limit and path from the query DTO', () => {
+      const query: IdempotencyUsageQueryDto = {
+        limit: 20,
+        path: '/transactions',
+      };
+      controller.getKeyUsage(query);
+      expect(monitorService.getKeyUsage).toHaveBeenCalledWith(
+        20,
+        '/transactions',
+      );
+    });
+
+    it('returns the data from the monitor service', () => {
+      const result = controller.getKeyUsage({});
+      expect(result).toEqual(mockUsage);
+    });
+
+    it('includes replay count in the response', () => {
+      const result = controller.getKeyUsage({});
+      expect(result[0]).toHaveProperty('replayCount');
+      expect(result[0].replayCount).toBe(2);
+    });
+
+    it('includes related entity type (route) in the response', () => {
+      const result = controller.getKeyUsage({});
+      for (const item of result) {
+        expect(item).toHaveProperty('path');
+      }
+    });
+  });
+});

--- a/backend/src/modules/admin/admin-idempotency.controller.ts
+++ b/backend/src/modules/admin/admin-idempotency.controller.ts
@@ -1,0 +1,139 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { Role } from '../../common/enums/role.enum';
+import { IdempotencyMonitorService } from '../../common/services/idempotency-monitor.service';
+import {
+  IdempotencyConflictQueryDto,
+  IdempotencyConflictDto,
+  IdempotencyConflictSummaryDto,
+  IdempotencyUsageQueryDto,
+  IdempotencyUsageRecordDto,
+} from './dto/admin-idempotency.dto';
+
+@ApiTags('admin/idempotency')
+@Controller('admin/idempotency')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN, Role.SUPER_ADMIN)
+@ApiBearerAuth()
+export class AdminIdempotencyController {
+  constructor(private readonly idempotencyMonitor: IdempotencyMonitorService) {}
+
+  /**
+   * GET /admin/idempotency/conflicts/summary
+   * Aggregate statistics: totals, breakdown by type and route, top offending keys.
+   * Sensitive payload data is never stored — only key identifiers and fingerprint hashes.
+   */
+  @Get('conflicts/summary')
+  @ApiOperation({
+    summary: 'Get idempotency conflict summary statistics',
+    description:
+      'Returns aggregate statistics about idempotency conflicts. ' +
+      'No sensitive payload data is included — only idempotency key identifiers, ' +
+      'SHA-256 request fingerprints, and route information.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Conflict summary statistics',
+    type: IdempotencyConflictSummaryDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
+  getConflictSummary(): IdempotencyConflictSummaryDto {
+    return this.idempotencyMonitor.getConflictSummary();
+  }
+
+  /**
+   * GET /admin/idempotency/conflicts
+   * List recent conflicts with optional filtering.
+   * Shows request fingerprint hash and timestamps — no sensitive payload data.
+   */
+  @Get('conflicts')
+  @ApiOperation({
+    summary: 'List recent idempotency conflicts',
+    description:
+      'Returns recent idempotency conflicts with request fingerprint hashes, ' +
+      'timestamps, conflict types, and related entity links. ' +
+      'Sensitive request payloads are never stored or exposed.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Max results (default 50, max 200)',
+  })
+  @ApiQuery({
+    name: 'conflictType',
+    required: false,
+    enum: ['payload_mismatch', 'concurrent_processing'],
+    description: 'Filter by conflict type',
+  })
+  @ApiQuery({
+    name: 'path',
+    required: false,
+    type: String,
+    description: 'Filter by route path (partial match)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of recent idempotency conflicts',
+    type: [IdempotencyConflictDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
+  getRecentConflicts(
+    @Query() query: IdempotencyConflictQueryDto,
+  ): IdempotencyConflictDto[] {
+    return this.idempotencyMonitor.getRecentConflicts(
+      query.limit ?? 50,
+      query.conflictType,
+      query.path,
+    );
+  }
+
+  /**
+   * GET /admin/idempotency/usage
+   * List recent idempotency key usage (first use + replay counts).
+   * Sorted by last-seen descending; useful for spotting high-replay keys.
+   */
+  @Get('usage')
+  @ApiOperation({
+    summary: 'List recent idempotency key usage',
+    description:
+      'Returns recent idempotency key usage records sorted by last-seen date. ' +
+      'Each record shows the key identifier, route, first/last seen timestamps, ' +
+      'and the number of cache-hit replays. No sensitive payload data is included.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Max results (default 50, max 200)',
+  })
+  @ApiQuery({
+    name: 'path',
+    required: false,
+    type: String,
+    description: 'Filter by route path (partial match)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of recent idempotency key usage records',
+    type: [IdempotencyUsageRecordDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
+  getKeyUsage(
+    @Query() query: IdempotencyUsageQueryDto,
+  ): IdempotencyUsageRecordDto[] {
+    return this.idempotencyMonitor.getKeyUsage(query.limit ?? 50, query.path);
+  }
+}

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -20,6 +20,7 @@ import { AdminDisputesController } from './admin-disputes.controller';
 import { AdminAuditLogsController } from './admin-audit-logs.controller';
 import { AdminNotificationsController } from './admin-notifications.controller';
 import { AdminTransactionsController } from './admin-transactions.controller';
+import { AdminIdempotencyController } from './admin-idempotency.controller';
 
 import { AdminUsersService } from './admin-users.service';
 import { AdminSavingsService } from './admin-savings.service';
@@ -84,6 +85,7 @@ import { JobQueueModule } from '../job-queue/job-queue.module';
     AdminTransactionsController,
     AdminDisputesController,
     AdminAuditLogsController,
+    AdminIdempotencyController,
   ],
   providers: [
     AdminUsersService,

--- a/backend/src/modules/admin/dto/admin-idempotency.dto.ts
+++ b/backend/src/modules/admin/dto/admin-idempotency.dto.ts
@@ -1,0 +1,160 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+// ─────────────────────────────────────────────────────────
+// Query DTOs
+// ─────────────────────────────────────────────────────────
+
+export class IdempotencyConflictQueryDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of results to return',
+    default: 50,
+    minimum: 1,
+    maximum: 200,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+
+  @ApiPropertyOptional({
+    description: 'Filter by conflict type',
+    enum: ['payload_mismatch', 'concurrent_processing'],
+  })
+  @IsOptional()
+  @IsEnum(['payload_mismatch', 'concurrent_processing'])
+  conflictType?: 'payload_mismatch' | 'concurrent_processing';
+
+  @ApiPropertyOptional({
+    description: 'Filter by route path (partial match)',
+  })
+  @IsOptional()
+  @IsString()
+  path?: string;
+}
+
+export class IdempotencyUsageQueryDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of results to return',
+    default: 50,
+    minimum: 1,
+    maximum: 200,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+
+  @ApiPropertyOptional({
+    description: 'Filter by route path (partial match)',
+  })
+  @IsOptional()
+  @IsString()
+  path?: string;
+}
+
+// ─────────────────────────────────────────────────────────
+// Response DTOs
+// ─────────────────────────────────────────────────────────
+
+export class IdempotencyConflictDto {
+  @ApiProperty({
+    description: 'The idempotency key submitted by the client',
+    example: 'req-abc-123',
+  })
+  idempotencyKey: string;
+
+  @ApiProperty({
+    description:
+      'SHA-256 fingerprint of the incoming request body — no sensitive payload data',
+    example: 'e3b0c44298fc1c149afbf4c8996fb924...',
+  })
+  requestFingerprintHash: string;
+
+  @ApiProperty({ example: 'POST' })
+  method: string;
+
+  @ApiProperty({ example: '/savings/deposit' })
+  path: string;
+
+  @ApiProperty({
+    enum: ['payload_mismatch', 'concurrent_processing'],
+    description:
+      'payload_mismatch: same key, different body hash. ' +
+      'concurrent_processing: same key already in-flight.',
+  })
+  conflictType: 'payload_mismatch' | 'concurrent_processing';
+
+  @ApiProperty({
+    description: 'ISO 8601 timestamp of the conflict',
+    example: '2026-06-30T02:00:00.000Z',
+  })
+  timestamp: string;
+
+  @ApiPropertyOptional({
+    description: 'Related entity type inferred from the route, if determinable',
+    example: 'savings',
+  })
+  relatedEntityType?: string;
+}
+
+export class IdempotencyConflictSummaryDto {
+  @ApiProperty({ description: 'Total conflicts in the in-memory buffer' })
+  total: number;
+
+  @ApiProperty({ description: 'Conflicts in the last 24 hours' })
+  last24h: number;
+
+  @ApiProperty({ description: 'Conflicts in the last hour' })
+  last1h: number;
+
+  @ApiProperty({
+    description: 'Breakdown by conflict type',
+    example: { payload_mismatch: 12, concurrent_processing: 3 },
+  })
+  byConflictType: Record<string, number>;
+
+  @ApiProperty({
+    description: 'Breakdown by route (method + path)',
+    example: { 'POST /savings/deposit': 7 },
+  })
+  byRoute: Record<string, number>;
+
+  @ApiProperty({
+    description: 'Top 10 most conflicting idempotency keys in the last 24 h',
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        idempotencyKey: { type: 'string' },
+        count: { type: 'number' },
+      },
+    },
+  })
+  topConflictingKeys: { idempotencyKey: string; count: number }[];
+}
+
+export class IdempotencyUsageRecordDto {
+  @ApiProperty({ description: 'The idempotency key submitted by the client' })
+  idempotencyKey: string;
+
+  @ApiProperty({ example: 'POST' })
+  method: string;
+
+  @ApiProperty({ example: '/savings/deposit' })
+  path: string;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp of first use' })
+  firstSeenAt: string;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp of last use or replay' })
+  lastSeenAt: string;
+
+  @ApiProperty({ description: 'Number of cache-hit replays for this key' })
+  replayCount: number;
+}


### PR DESCRIPTION
Closes #1146 

Add an admin-only observability layer for idempotency key activity so operators can diagnose repeated requests and 409 conflicts without exposing sensitive payload data.

Changes:
- IdempotencyMonitorService (common/services): in-memory circular-buffer tracker (1 000 conflicts, 5 000 key records) that listens for EventEmitter2 events emitted by the interceptor.
  * idempotency.conflict  – payload_mismatch or concurrent_processing
  * idempotency.replay    – cache-hit replays
  * idempotency.first_use – first successful use of a key
  Exposes getRecentConflicts(), getConflictSummary(), and getKeyUsage()
  query methods. Registered as a global provider in CommonModule.

- IdempotencyInterceptor: inject optional EventEmitter2 and emit the three events above. Stores only the SHA-256 fingerprint of the request body — never the raw payload — satisfying the sensitive-data redaction requirement.

- AdminIdempotencyController (admin module): three read-only endpoints protected by JwtAuthGuard + RolesGuard(ADMIN | SUPER_ADMIN): GET /admin/idempotency/conflicts/summary  – aggregate stats
    GET /admin/idempotency/conflicts          – recent conflicts list
    GET /admin/idempotency/usage              – recent key usage

- DTOs: IdempotencyConflictQueryDto, IdempotencyUsageQueryDto (with class-validator) and Swagger-annotated response types.

- Unit tests: 23 tests for IdempotencyMonitorService (circular buffer eviction, filtering, summary stats, first-use/replay tracking) and 12 tests for AdminIdempotencyController (endpoint behaviour, query param forwarding, no sensitive data in responses). All 35 pass.