### PR TITLE
feat(backend): support compressed request bodies with zip-bomb safety…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -156,6 +156,23 @@ TEST_MODE=false
 # Optional: JSON string overriding default stellar fixture values.
 # TEST_MODE_STELLAR_FIXTURES={"health":{"ok":true},"events":[],"delegation":null}
 
+# ── Compression ───────────────────────────────────────────────────────────────
+# Response compression: only payloads larger than this many bytes are compressed.
+COMPRESSION_THRESHOLD=1024
+# Maximum size of a parsed request body. Also caps the *decompressed* size of a
+# compressed (gzip/deflate) request body — an over-sized payload is rejected
+# with HTTP 413 before being fully buffered (zip-bomb protection).
+JSON_BODY_LIMIT=1mb
+URLENCODED_BODY_LIMIT=1mb
+# Inbound request body decompression. Set to false to reject any request that
+# carries a non-identity Content-Encoding with HTTP 415.
+REQUEST_DECOMPRESSION_ENABLED=true
+# Comma-separated list of accepted request Content-Encodings (besides identity).
+REQUEST_ALLOWED_ENCODINGS=gzip,deflate
+# Optional override for the max decompressed request body size.
+# Defaults to JSON_BODY_LIMIT when unset.
+# REQUEST_MAX_DECOMPRESSED_SIZE=1mb
+
 # ── Feature Flags ─────────────────────────────────────────────────────────────
 # No additional backend config required.
 # Flags are stored in the database and served via GET /api/v2/feature-flags.

--- a/backend/docs/REQUEST_COMPRESSION.md
+++ b/backend/docs/REQUEST_COMPRESSION.md
@@ -1,0 +1,84 @@
+# Request Body Compression
+
+The API accepts **compressed request bodies** so clients sending large JSON
+payloads (bulk operations, evidence metadata) can reduce upload bandwidth.
+Support is opt-in for the client (via the `Content-Encoding` header) and is
+guarded with strict safety limits to prevent zip-bomb attacks.
+
+> Note: this is **inbound** decompression (request bodies). Outbound
+> **response** compression (gzip/brotli) is configured separately in
+> `main.ts` via the `compression` middleware.
+
+## Sending a compressed request
+
+Compress the body with `gzip` or `deflate` and set the matching header:
+
+```bash
+# Compress a JSON file and POST it
+gzip -c payload.json | \
+  curl -X POST https://api.nestera.io/api/v2/<endpoint> \
+    -H "Authorization: Bearer <token>" \
+    -H "Content-Type: application/json" \
+    -H "Content-Encoding: gzip" \
+    --data-binary @-
+```
+
+The server inflates the body transparently; controllers and validation see the
+decoded JSON exactly as if it had been sent uncompressed.
+
+### Supported encodings
+
+| `Content-Encoding` | Behaviour                                              |
+| ------------------ | ----------------------------------------------------- |
+| _(absent)_         | Body read as-is.                                       |
+| `identity`         | Treated as uncompressed.                               |
+| `gzip`             | Inflated, subject to the decompressed-size limit.     |
+| `deflate`          | Inflated, subject to the decompressed-size limit.     |
+| anything else      | Rejected with **415 Unsupported Media Type**.         |
+| stacked (`a, b`)   | Rejected with **415** (nested-bomb vector).           |
+
+## Safety limits (zip-bomb protection)
+
+A small compressed payload can inflate to gigabytes. Two layers protect the
+server:
+
+1. **Encoding allow-list** — the `RequestDecompressionGuard`
+   (`src/common/middleware/request-decompression.middleware.ts`) runs before the
+   body parser and rejects any encoding that is not `gzip`/`deflate`/`identity`,
+   as well as stacked encodings, with **415**. It can also disable compressed
+   bodies entirely.
+2. **Decompressed-size cap** — the body parser inflates the stream and enforces
+   the configured limit against the **decompressed** bytes, aborting with
+   **413 Payload Too Large** the moment the inflated output exceeds the limit.
+   The payload is never fully buffered, so a bomb cannot exhaust memory.
+
+## Configuration
+
+| Env var                         | Default            | Description                                                                 |
+| ------------------------------- | ------------------ | --------------------------------------------------------------------------- |
+| `REQUEST_DECOMPRESSION_ENABLED` | `true`             | When `false`, any non-identity `Content-Encoding` is rejected with **415**. |
+| `REQUEST_ALLOWED_ENCODINGS`     | `gzip,deflate`     | Comma-separated allow-list of accepted request encodings.                   |
+| `REQUEST_MAX_DECOMPRESSED_SIZE` | `JSON_BODY_LIMIT`  | Max decompressed body size (e.g. `1mb`, `512kb`). Enforced with **413**.    |
+| `JSON_BODY_LIMIT`               | `1mb`              | Max JSON body size; default cap for decompressed bodies.                    |
+| `URLENCODED_BODY_LIMIT`         | `1mb`              | Max urlencoded body size.                                                   |
+
+## Error responses
+
+| Status | When                                                                 |
+| ------ | -------------------------------------------------------------------- |
+| `413`  | Decompressed body exceeds `REQUEST_MAX_DECOMPRESSED_SIZE`.           |
+| `415`  | Unsupported encoding, stacked encoding, or feature disabled.         |
+
+`415` responses follow the standard error envelope with one of these
+`errorCode` values:
+
+- `REQ_COMPRESSION_DISABLED`
+- `REQ_COMPRESSION_UNSUPPORTED`
+- `REQ_COMPRESSION_STACKED`
+
+## Tests
+
+Behaviour is covered by
+`src/common/middleware/request-decompression.middleware.spec.ts`, including
+zip-bomb rejection (gzip and deflate payloads that inflate past the limit must
+return **413**) and unsupported/disabled-encoding handling.

--- a/backend/src/common/middleware/request-decompression.middleware.spec.ts
+++ b/backend/src/common/middleware/request-decompression.middleware.spec.ts
@@ -1,0 +1,267 @@
+import * as express from 'express';
+import { Express } from 'express';
+import * as zlib from 'zlib';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import {
+  createRequestDecompressionGuard,
+  RequestDecompressionOptions,
+  REQUEST_DECOMPRESSION_ERROR_CODES,
+} from './request-decompression.middleware';
+
+/**
+ * Builds a minimal Express app wired exactly like `main.ts`: the decompression
+ * guard runs first, followed by the body parsers that perform the actual
+ * inflation and enforce the decompressed-size limit.
+ */
+function buildApp(
+  overrides: Partial<RequestDecompressionOptions> = {},
+  limit = '1mb',
+): Express {
+  const options: RequestDecompressionOptions = {
+    enabled: true,
+    allowedEncodings: ['gzip', 'deflate'],
+    ...overrides,
+  };
+
+  const app = express();
+  app.use(createRequestDecompressionGuard(options));
+  app.use(express.json({ limit, inflate: options.enabled }));
+  app.post('/echo', (req, res) => {
+    res.status(200).json({ received: req.body });
+  });
+  return app;
+}
+
+interface RawResponse {
+  status: number;
+  body: unknown;
+  text: string;
+}
+
+/**
+ * Sends a raw request body to the app over a real socket. We deliberately
+ * bypass supertest/superagent here: superagent treats a Buffer passed to
+ * `.send()` as a plain object and JSON-serializes it, which would corrupt the
+ * compressed bytes. A raw `http` request guarantees the exact bytes are sent.
+ */
+function sendRaw(
+  app: Express,
+  headers: Record<string, string>,
+  body: Buffer,
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      const req = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          method: 'POST',
+          path: '/echo',
+          headers: { 'Content-Length': body.length, ...headers },
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => {
+            server.close();
+            const text = Buffer.concat(chunks).toString('utf8');
+            let parsed: unknown = text;
+            try {
+              parsed = JSON.parse(text);
+            } catch {
+              /* leave as text */
+            }
+            resolve({ status: res.statusCode ?? 0, body: parsed, text });
+          });
+        },
+      );
+      req.on('error', (err) => {
+        server.close();
+        reject(err);
+      });
+      req.end(body);
+    });
+  });
+}
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+describe('createRequestDecompressionGuard', () => {
+  describe('uncompressed requests', () => {
+    it('passes plain JSON straight through', async () => {
+      const app = buildApp();
+      const payload = { hello: 'world' };
+
+      const res = await sendRaw(
+        app,
+        JSON_HEADERS,
+        Buffer.from(JSON.stringify(payload)),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ received: payload });
+    });
+  });
+
+  describe('supported compressed requests', () => {
+    it('accepts and inflates a gzip-encoded body within the limit', async () => {
+      const app = buildApp();
+      const payload = { items: Array.from({ length: 50 }, (_, i) => i) };
+      const compressed = zlib.gzipSync(Buffer.from(JSON.stringify(payload)));
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'gzip' },
+        compressed,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ received: payload });
+    });
+
+    it('accepts and inflates a deflate-encoded body within the limit', async () => {
+      const app = buildApp();
+      const payload = { message: 'compressed via deflate' };
+      const compressed = zlib.deflateSync(Buffer.from(JSON.stringify(payload)));
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'deflate' },
+        compressed,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ received: payload });
+    });
+  });
+
+  describe('zip bomb protection', () => {
+    it('rejects a gzip body that inflates beyond the limit with HTTP 413', async () => {
+      // A small (~few KB) compressed payload that decompresses to ~10MB —
+      // far beyond the 1mb limit. The parser must abort with 413.
+      const app = buildApp({}, '1mb');
+      const huge = 'x'.repeat(10 * 1024 * 1024);
+      const compressed = zlib.gzipSync(
+        Buffer.from(JSON.stringify({ bomb: huge })),
+      );
+
+      // Sanity: the compressed payload itself is tiny.
+      expect(compressed.length).toBeLessThan(1024 * 1024);
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'gzip' },
+        compressed,
+      );
+
+      expect(res.status).toBe(413);
+    });
+
+    it('rejects a deflate body that inflates beyond the limit with HTTP 413', async () => {
+      const app = buildApp({}, '1mb');
+      const huge = 'y'.repeat(10 * 1024 * 1024);
+      const compressed = zlib.deflateSync(
+        Buffer.from(JSON.stringify({ bomb: huge })),
+      );
+
+      expect(compressed.length).toBeLessThan(1024 * 1024);
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'deflate' },
+        compressed,
+      );
+
+      expect(res.status).toBe(413);
+    });
+  });
+
+  describe('unsupported encodings', () => {
+    it('rejects an unsupported Content-Encoding (br) with HTTP 415', async () => {
+      const app = buildApp();
+      const compressed = zlib.brotliCompressSync(
+        Buffer.from(JSON.stringify({ hello: 'brotli' })),
+      );
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'br' },
+        compressed,
+      );
+
+      expect(res.status).toBe(415);
+      expect((res.body as { errorCode: string }).errorCode).toBe(
+        REQUEST_DECOMPRESSION_ERROR_CODES.UNSUPPORTED_ENCODING,
+      );
+    });
+
+    it('rejects stacked Content-Encoding with HTTP 415', async () => {
+      const app = buildApp();
+      const compressed = zlib.gzipSync(
+        zlib.gzipSync(Buffer.from(JSON.stringify({ nested: true }))),
+      );
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'gzip, gzip' },
+        compressed,
+      );
+
+      expect(res.status).toBe(415);
+      expect((res.body as { errorCode: string }).errorCode).toBe(
+        REQUEST_DECOMPRESSION_ERROR_CODES.STACKED_ENCODING,
+      );
+    });
+
+    it('treats an identity Content-Encoding as uncompressed', async () => {
+      const app = buildApp();
+      const payload = { plain: true };
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'identity' },
+        Buffer.from(JSON.stringify(payload)),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ received: payload });
+    });
+  });
+
+  describe('feature disabled', () => {
+    it('rejects any compressed body with HTTP 415 when disabled', async () => {
+      const app = buildApp({ enabled: false });
+      const compressed = zlib.gzipSync(
+        Buffer.from(JSON.stringify({ hello: 'world' })),
+      );
+
+      const res = await sendRaw(
+        app,
+        { ...JSON_HEADERS, 'Content-Encoding': 'gzip' },
+        compressed,
+      );
+
+      expect(res.status).toBe(415);
+      expect((res.body as { errorCode: string }).errorCode).toBe(
+        REQUEST_DECOMPRESSION_ERROR_CODES.DISABLED,
+      );
+    });
+
+    it('still accepts uncompressed bodies when disabled', async () => {
+      const app = buildApp({ enabled: false });
+      const payload = { still: 'works' };
+
+      const res = await sendRaw(
+        app,
+        JSON_HEADERS,
+        Buffer.from(JSON.stringify(payload)),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ received: payload });
+    });
+  });
+});

--- a/backend/src/common/middleware/request-decompression.middleware.ts
+++ b/backend/src/common/middleware/request-decompression.middleware.ts
@@ -1,0 +1,131 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Options controlling inbound (request body) decompression.
+ */
+export interface RequestDecompressionOptions {
+  /**
+   * When false, any request carrying a non-identity `Content-Encoding`
+   * is rejected with 415. When true, supported encodings are allowed
+   * through to the body parser, which inflates them.
+   */
+  enabled: boolean;
+  /**
+   * Lower-cased list of accepted content encodings (besides `identity`).
+   * Only encodings the downstream body parser can safely inflate should
+   * be listed here — currently `gzip` and `deflate`.
+   */
+  allowedEncodings: string[];
+}
+
+/**
+ * Error codes surfaced by the guard. These mirror the shape produced by the
+ * global exception filter so clients see a consistent error envelope, even
+ * though this guard runs as raw Express middleware (before Nest filters).
+ */
+export const REQUEST_DECOMPRESSION_ERROR_CODES = {
+  DISABLED: 'REQ_COMPRESSION_DISABLED',
+  UNSUPPORTED_ENCODING: 'REQ_COMPRESSION_UNSUPPORTED',
+  STACKED_ENCODING: 'REQ_COMPRESSION_STACKED',
+} as const;
+
+function parseContentEncoding(header: string | string[] | undefined): string[] {
+  if (!header) {
+    return [];
+  }
+  const raw = Array.isArray(header) ? header.join(',') : header;
+  return raw
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function reject(
+  res: Response,
+  req: Request,
+  errorCode: string,
+  message: string,
+): void {
+  res.status(415).json({
+    success: false,
+    statusCode: 415,
+    errorCode,
+    message,
+    timestamp: new Date().toISOString(),
+    path: req.originalUrl,
+  });
+}
+
+/**
+ * Builds an Express middleware that gates compressed request bodies.
+ *
+ * It does NOT inflate the body itself — that is delegated to the battle-tested
+ * `body-parser` (`express.json` / `express.urlencoded`) layer, which enforces
+ * the configured `limit` against the *decompressed* byte stream and aborts with
+ * HTTP 413 once that limit is exceeded. This is the zip-bomb safeguard: a tiny
+ * compressed payload that inflates past the limit is rejected mid-stream rather
+ * than fully buffered.
+ *
+ * This guard's job is policy enforcement that the parser does not own:
+ *   - reject non-identity encodings when the feature is disabled (415),
+ *   - reject encodings the parser cannot safely inflate (415),
+ *   - reject stacked encodings (e.g. `gzip, gzip`) that could nest a bomb (415).
+ *
+ * Requests with no `Content-Encoding` (or `identity`) pass straight through.
+ */
+export function createRequestDecompressionGuard(
+  options: RequestDecompressionOptions,
+): RequestHandler {
+  const allowed = new Set(
+    options.allowedEncodings.map((encoding) => encoding.toLowerCase()),
+  );
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const encodings = parseContentEncoding(req.headers['content-encoding']);
+    const nonIdentity = encodings.filter((encoding) => encoding !== 'identity');
+
+    // No compression requested — nothing to guard.
+    if (nonIdentity.length === 0) {
+      next();
+      return;
+    }
+
+    if (!options.enabled) {
+      reject(
+        res,
+        req,
+        REQUEST_DECOMPRESSION_ERROR_CODES.DISABLED,
+        'Compressed request bodies are not supported by this server.',
+      );
+      return;
+    }
+
+    // Stacked encodings (e.g. "gzip, deflate") are a vector for nested zip
+    // bombs and are not inflated by the body parser. Reject outright.
+    if (nonIdentity.length > 1) {
+      reject(
+        res,
+        req,
+        REQUEST_DECOMPRESSION_ERROR_CODES.STACKED_ENCODING,
+        'Stacked Content-Encoding is not supported. Send a single encoding.',
+      );
+      return;
+    }
+
+    const unsupported = nonIdentity.filter(
+      (encoding) => !allowed.has(encoding),
+    );
+    if (unsupported.length > 0) {
+      reject(
+        res,
+        req,
+        REQUEST_DECOMPRESSION_ERROR_CODES.UNSUPPORTED_ENCODING,
+        `Unsupported Content-Encoding: ${unsupported.join(', ')}. ` +
+          `Supported encodings: ${[...allowed].join(', ')}.`,
+      );
+      return;
+    }
+
+    next();
+  };
+}

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -361,6 +361,24 @@ export default () => ({
     threshold: parseInt(process.env.COMPRESSION_THRESHOLD || '1024', 10),
     jsonBodyLimit: process.env.JSON_BODY_LIMIT || '1mb',
     urlencodedBodyLimit: process.env.URLENCODED_BODY_LIMIT || '1mb',
+    // Inbound (request body) decompression of gzip/deflate payloads.
+    request: {
+      // Toggle support for compressed request bodies (default: enabled).
+      enabled: process.env.REQUEST_DECOMPRESSION_ENABLED !== 'false',
+      // Encodings the body parser is allowed to inflate. Restricted to the
+      // formats body-parser can safely handle.
+      allowedEncodings: (process.env.REQUEST_ALLOWED_ENCODINGS || 'gzip,deflate')
+        .split(',')
+        .map((encoding) => encoding.trim().toLowerCase())
+        .filter(Boolean),
+      // Maximum *decompressed* body size. Enforced by the body parser against
+      // the inflated stream, so an over-sized zip bomb is aborted with HTTP 413
+      // before it is fully buffered. Defaults to the JSON body limit.
+      maxDecompressedSize:
+        process.env.REQUEST_MAX_DECOMPRESSED_SIZE ||
+        process.env.JSON_BODY_LIMIT ||
+        '1mb',
+    },
   },
   multiTenant: {
     enabled: process.env.MULTI_TENANT_ENABLED === 'true',

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -48,4 +48,13 @@ export const envValidationSchema = Joi.object({
   MAIL_USER: Joi.string().optional(),
   MAIL_PASS: Joi.string().optional(),
   MAIL_FROM: Joi.string().optional(),
+
+  // ── Compression (response + request body) ──────────────────────────────────
+  COMPRESSION_THRESHOLD: Joi.number().integer().min(0).default(1024).optional(),
+  JSON_BODY_LIMIT: Joi.string().default('1mb').optional(),
+  URLENCODED_BODY_LIMIT: Joi.string().default('1mb').optional(),
+  // Inbound gzip/deflate request body decompression and zip-bomb safety limit.
+  REQUEST_DECOMPRESSION_ENABLED: Joi.boolean().default(true).optional(),
+  REQUEST_ALLOWED_ENCODINGS: Joi.string().default('gzip,deflate').optional(),
+  REQUEST_MAX_DECOMPRESSED_SIZE: Joi.string().optional(),
 }).or('DATABASE_URL', 'DB_HOST'); // enforce at least one DB connection strategy

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -23,6 +23,7 @@ import {
 import { VersionAnalyticsInterceptor } from './common/versioning/version-analytics.interceptor';
 import { VersionAnalyticsService } from './common/versioning/version-analytics.service';
 import { GracefulShutdownService } from './common/services/graceful-shutdown.service';
+import { createRequestDecompressionGuard } from './common/middleware/request-decompression.middleware';
 import { ContractCompatibilityService } from './common/services/contract-compatibility.service';
 import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { flattenValidationErrors } from './common/validators/validation-error.utils';
@@ -109,11 +110,46 @@ async function bootstrap() {
     }),
   );
 
-  // Request body size limits
-  const jsonBodyLimit = process.env.JSON_BODY_LIMIT || '1mb';
-  const urlencodedLimit = process.env.URLENCODED_BODY_LIMIT || '1mb';
-  app.use(express.json({ limit: jsonBodyLimit }));
-  app.use(express.urlencoded({ limit: urlencodedLimit, extended: true }));
+  // Inbound request body decompression (gzip/deflate) with safety limits.
+  // The guard restricts which Content-Encodings are accepted and can disable
+  // compressed bodies entirely; the body parser (below) performs the actual
+  // inflation and enforces `limit` against the *decompressed* stream — a zip
+  // bomb is aborted with HTTP 413 before it is fully buffered.
+  const requestDecompression = configService.get<{
+    enabled: boolean;
+    allowedEncodings: string[];
+    maxDecompressedSize: string;
+  }>('compression.request') ?? {
+    enabled: true,
+    allowedEncodings: ['gzip', 'deflate'],
+    maxDecompressedSize: process.env.JSON_BODY_LIMIT || '1mb',
+  };
+  app.use(
+    createRequestDecompressionGuard({
+      enabled: requestDecompression.enabled,
+      allowedEncodings: requestDecompression.allowedEncodings,
+    }),
+  );
+
+  // Request body size limits. `limit` caps the decompressed payload size and
+  // `inflate` toggles gzip/deflate decompression in line with the guard.
+  const jsonBodyLimit = requestDecompression.maxDecompressedSize;
+  const urlencodedLimit =
+    process.env.URLENCODED_BODY_LIMIT ||
+    requestDecompression.maxDecompressedSize;
+  app.use(
+    express.json({
+      limit: jsonBodyLimit,
+      inflate: requestDecompression.enabled,
+    }),
+  );
+  app.use(
+    express.urlencoded({
+      limit: urlencodedLimit,
+      extended: true,
+      inflate: requestDecompression.enabled,
+    }),
+  );
 
   app.use(
     helmet({


### PR DESCRIPTION
Close #1137 

### Summary
Adds support for **compressed request bodies** (gzip/deflate) so clients sending large JSON payloads — bulk operations, evidence metadata — can reduce upload bandwidth. Decompression is guarded with strict safety limits to prevent zip-bomb attacks.

> This is **inbound** request-body decompression. It does not change the existing **outbound** response compression in `main.ts`.

### How it works
Express's body parser already inflates gzip/deflate bodies, and `body-parser`/`raw-body` enforce the size `limit` against the **decompressed** stream — aborting with **413** the moment inflated output exceeds the limit, without fully buffering. This PR leverages that battle-tested path and adds an explicit policy layer on top:

- A new **`RequestDecompressionGuard`** middleware runs *before* body parsing and:
  - allows only `gzip` / `deflate` / `identity` encodings,
  - rejects unsupported encodings (e.g. `br`) with **415**,
  - rejects **stacked** encodings (`gzip, gzip` — a nested-bomb vector) with **415**,
  - rejects all compressed bodies with **415** when the feature is disabled.
- The body parser is wired with `inflate` + a `limit` equal to the configured max **decompressed** size (zip-bomb cap).

### Changes
| File | Change |
| --- | --- |
| `src/common/middleware/request-decompression.middleware.ts` | New guard middleware + typed error codes |
| `src/main.ts` | Register guard; wire `inflate` + decompressed-size `limit` into body parsers |
| `src/config/configuration.ts` | New `compression.request` config (`enabled`, `allowedEncodings`, `maxDecompressedSize`) |
| `src/config/env.validation.ts` | Joi validation for compression env vars |
| `.env.example` | Documented compression env vars |
| `docs/REQUEST_COMPRESSION.md` | Usage, supported encodings, safety limits, config, error reference |
| `src/common/middleware/request-decompression.middleware.spec.ts` | Test suite (10 tests) |

### Configuration
| Env var | Default | Description |
| --- | --- | --- |
| `REQUEST_DECOMPRESSION_ENABLED` | `true` | When `false`, any non-identity `Content-Encoding` → **415** |
| `REQUEST_ALLOWED_ENCODINGS` | `gzip,deflate` | Allow-list of accepted request encodings |
| `REQUEST_MAX_DECOMPRESSED_SIZE` | `JSON_BODY_LIMIT` | Max decompressed body size; enforced with **413** |

### Acceptance Criteria
- [x] Compressed request support added with safety limits
- [x] Tests verify rejected zip-bomb scenarios

### Testing
All 10 tests pass; production build typechecks; lint + prettier clean.

- gzip **and** deflate zip bombs (tiny payload inflating to ~10MB vs 1mb limit) → **413**
- valid gzip/deflate bodies within limit inflate correctly → **200**
- unsupported (`br`), stacked, and disabled-feature encodings → **415**
- plain / `identity` bodies pass through unchanged

```bash
# Send a gzip-compressed JSON request
gzip -c payload.json | curl -X POST https://api.nestera.io/api/v2/<endpoint> \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -H "Content-Encoding: gzip" \
  --data-binary @-
```

### Notes
- No changes to outbound response compression.
- Backwards compatible: uncompressed requests behave exactly as before.
