### PR TITLE
feat(audit): add system audit logging for background jobs

### DIFF
--- a/backend/src/common/entities/audit-log.entity.ts
+++ b/backend/src/common/entities/audit-log.entity.ts
@@ -35,6 +35,11 @@ export enum AuditAction {
   DEPOSIT = 'DEPOSIT',
   WITHDRAW = 'WITHDRAW',
   VOTE = 'VOTE',
+  // Background / automated job actions
+  RECONCILE = 'RECONCILE',
+  CLEANUP = 'CLEANUP',
+  ARCHIVE = 'ARCHIVE',
+  EXPORT_JOB = 'EXPORT_JOB',
 }
 
 export enum AuditResourceType {
@@ -50,7 +55,15 @@ export enum AuditResourceType {
   WITHDRAWAL_REQUEST = 'WITHDRAWAL_REQUEST',
   SYSTEM = 'SYSTEM',
   GOVERNANCE = 'GOVERNANCE',
+  /** Background jobs and scheduled tasks */
+  JOB = 'JOB',
 }
+
+/**
+ * Canonical actor identifier used for automated/background processes.
+ * Use this instead of a real user ID when there is no human initiator.
+ */
+export const SYSTEM_ACTOR = 'SYSTEM';
 
 @Entity('audit_logs')
 @Index('idx_audit_logs_correlation_id', ['correlationId'])
@@ -68,6 +81,13 @@ export class AuditLog {
 
   @Column({ nullable: true })
   requestId: string;
+
+  /**
+   * ID of the background job (Bull/BullMQ job.id) that triggered this entry.
+   * Populated only for automated/system-initiated audit entries.
+   */
+  @Column({ nullable: true })
+  jobId: string;
 
   @CreateDateColumn()
   timestamp: Date;

--- a/backend/src/common/services/audit-log.service.ts
+++ b/backend/src/common/services/audit-log.service.ts
@@ -10,6 +10,8 @@ import {
 export interface CreateAuditLogDto {
   correlationId?: string;
   requestId?: string;
+  /** Background job ID (Bull/BullMQ job.id). Only set for system-initiated entries. */
+  jobId?: string;
   endpoint?: string;
   method?: string;
   action?: AuditAction;

--- a/backend/src/migrations/1804000000000-AddSystemAuditLoggingSupport.ts
+++ b/backend/src/migrations/1804000000000-AddSystemAuditLoggingSupport.ts
@@ -1,0 +1,67 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableIndex,
+} from 'typeorm';
+
+/**
+ * Migration: Add support for background/system audit log entries
+ *
+ * Changes:
+ *  1. Add `job_id` column – stores Bull/BullMQ job.id for background jobs.
+ *  2. Extend `action` enum with RECONCILE, CLEANUP, ARCHIVE, EXPORT_JOB.
+ *  3. Extend `resource_type` enum with JOB.
+ */
+export class AddSystemAuditLoggingSupport1804000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Add job_id column
+    await queryRunner.addColumn(
+      'audit_logs',
+      new TableColumn({
+        name: 'job_id',
+        type: 'varchar',
+        isNullable: true,
+        comment:
+          'Bull/BullMQ job ID for background/automated audit entries (null for user-initiated entries)',
+      }),
+    );
+
+    // Index for fast lookups by job_id
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({
+        name: 'idx_audit_logs_job_id',
+        columnNames: ['job_id'],
+      }),
+    );
+
+    // 2. Extend the action enum (PostgreSQL requires renaming the type)
+    await queryRunner.query(
+      `ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS 'RECONCILE'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS 'CLEANUP'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS 'ARCHIVE'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS 'EXPORT_JOB'`,
+    );
+
+    // 3. Extend the resource_type enum
+    await queryRunner.query(
+      `ALTER TYPE "audit_logs_resource_type_enum" ADD VALUE IF NOT EXISTS 'JOB'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove index + column (PostgreSQL enum values cannot be removed without recreating the type,
+    // so we leave the enum values as-is on rollback – they are safely ignored by older code)
+    await queryRunner.dropIndex('audit_logs', 'idx_audit_logs_job_id');
+    await queryRunner.dropColumn('audit_logs', 'job_id');
+  }
+}

--- a/backend/src/modules/admin/admin-audit-logs-archival.service.ts
+++ b/backend/src/modules/admin/admin-audit-logs-archival.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { Cron } from '@nestjs/schedule';
@@ -14,7 +14,13 @@ import {
   PutObjectCommand,
   DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
-import { AuditLog } from '../../common/entities/audit-log.entity';
+import {
+  AuditLog,
+  AuditAction,
+  AuditResourceType,
+  SYSTEM_ACTOR,
+} from '../../common/entities/audit-log.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ShutdownTrackedTask } from '../../common/decorators/shutdown-task.decorator';
 
@@ -40,6 +46,7 @@ export class AdminAuditLogsArchivalService {
     private readonly auditLogRepository: Repository<AuditLog>,
     private readonly configService: ConfigService,
     private readonly eventEmitter?: EventEmitter2,
+    @Optional() private readonly auditLogService?: AuditLogService,
   ) {
     this.config = {
       retentionDays:
@@ -81,8 +88,16 @@ export class AdminAuditLogsArchivalService {
   @ShutdownTrackedTask()
   @Cron('0 1 * * *')
   async archiveOldLogs(): Promise<void> {
+    const startedAt = Date.now();
+    const cutoffDate = this.getArchivalCutoffDate();
+
+    // Capture before-state for audit diff
+    const logsBeforeArchival = await this.auditLogRepository.count({
+      where: { timestamp: LessThan(cutoffDate) },
+    });
+    const totalBeforeArchival = await this.auditLogRepository.count();
+
     try {
-      const cutoffDate = this.getArchivalCutoffDate();
       this.logger.log(
         `Starting audit log archival for logs before ${cutoffDate.toISOString()}`,
       );
@@ -96,6 +111,26 @@ export class AdminAuditLogsArchivalService {
         cutoffDate,
         timestamp: new Date(),
       });
+
+      // Audit log – successful archival (SYSTEM actor)
+      await this.auditLogService?.log({
+        actor: SYSTEM_ACTOR,
+        action: AuditAction.ARCHIVE,
+        resourceType: AuditResourceType.JOB,
+        description: `Audit log archival completed: ${count} logs archived (cutoff=${cutoffDate.toISOString()}, retentionDays=${this.config.retentionDays}).`,
+        previousValue: {
+          totalLogsInDb: totalBeforeArchival,
+          logsEligibleForArchival: logsBeforeArchival,
+          cutoffDate: cutoffDate.toISOString(),
+        },
+        newValue: {
+          archivedCount: count,
+          totalLogsAfterArchival: totalBeforeArchival - count,
+          completedAt: new Date().toISOString(),
+        },
+        durationMs: Date.now() - startedAt,
+        success: true,
+      });
     } catch (error) {
       const msg = (error as Error).message;
       this.logger.error(`Audit log archival failed: ${msg}`);
@@ -103,6 +138,23 @@ export class AdminAuditLogsArchivalService {
       this.eventEmitter?.emit('audit.archival.failed', {
         error: msg,
         timestamp: new Date(),
+      });
+
+      // Audit log – failed archival
+      await this.auditLogService?.log({
+        actor: SYSTEM_ACTOR,
+        action: AuditAction.ARCHIVE,
+        resourceType: AuditResourceType.JOB,
+        description: `Audit log archival failed: ${msg}`,
+        previousValue: {
+          totalLogsInDb: totalBeforeArchival,
+          logsEligibleForArchival: logsBeforeArchival,
+          cutoffDate: cutoffDate.toISOString(),
+        },
+        newValue: { error: msg },
+        durationMs: Date.now() - startedAt,
+        success: false,
+        errorMessage: msg,
       });
     }
   }

--- a/backend/src/modules/admin/processors/admin-export.processor.ts
+++ b/backend/src/modules/admin/processors/admin-export.processor.ts
@@ -14,6 +14,9 @@ export class AdminExportProcessor {
 
   @Process(ADMIN_EXPORT_JOB_NAME)
   async handle(job: Job<{ exportJobId: string }>): Promise<void> {
-    await this.adminExportService.processExportJob(job.data.exportJobId);
+    await this.adminExportService.processExportJob(
+      job.data.exportJobId,
+      String(job.id),
+    );
   }
 }

--- a/backend/src/modules/admin/services/admin-export.service.ts
+++ b/backend/src/modules/admin/services/admin-export.service.ts
@@ -15,6 +15,12 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { DataScopeService } from '../../../common/services/data-scope.service';
+import { AuditLogService } from '../../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+  SYSTEM_ACTOR,
+} from '../../../common/entities/audit-log.entity';
 import { Role } from '../../../common/enums/role.enum';
 import { Transaction } from '../../transactions/entities/transaction.entity';
 import { Dispute } from '../../disputes/entities/dispute.entity';
@@ -50,6 +56,7 @@ export class AdminExportService {
     @InjectQueue(ADMIN_EXPORT_QUEUE)
     private readonly exportQueue: Queue,
     private readonly dataScopeService: DataScopeService,
+    private readonly auditLogService: AuditLogService,
   ) {
     fs.mkdirSync(this.exportDir, { recursive: true });
   }
@@ -146,7 +153,7 @@ export class AdminExportService {
     stream.end();
   }
 
-  async processExportJob(jobId: string): Promise<void> {
+  async processExportJob(jobId: string, bullJobId?: string): Promise<void> {
     const job = await this.exportJobRepository.findOne({
       where: { id: jobId },
     });
@@ -164,6 +171,17 @@ export class AdminExportService {
     if (job.status === AdminExportStatus.COMPLETED && job.filePath) {
       return;
     }
+
+    const startedAt = Date.now();
+
+    // Capture before-state for audit diff
+    const beforeState = {
+      jobId: job.id,
+      dataType: job.dataType,
+      status: job.status,
+      requestedBy: job.userId,
+      requestedByRole: job.requestedByRole,
+    };
 
     await this.exportJobRepository.update(job.id, {
       status: AdminExportStatus.PROCESSING,
@@ -210,6 +228,25 @@ export class AdminExportService {
       });
 
       this.logger.log(`Admin export job ${job.id} completed`);
+
+      // Audit log – successful background export
+      await this.auditLogService.log({
+        actor: SYSTEM_ACTOR,
+        action: AuditAction.EXPORT_JOB,
+        resourceType: AuditResourceType.JOB,
+        resourceId: job.id,
+        jobId: bullJobId ?? job.queueJobId ?? job.id,
+        description: `Admin export job completed: dataType=${job.dataType}, rows=${rows.length}, requestedBy=${job.userId}`,
+        previousValue: beforeState,
+        newValue: {
+          status: AdminExportStatus.COMPLETED,
+          fileName,
+          rowCount: rows.length,
+          completedAt: new Date().toISOString(),
+        },
+        durationMs: Date.now() - startedAt,
+        success: true,
+      });
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Unknown export error';
@@ -218,6 +255,22 @@ export class AdminExportService {
         errorMessage: message,
       });
       this.logger.error(`Admin export job ${job.id} failed: ${message}`);
+
+      // Audit log – failed background export
+      await this.auditLogService.log({
+        actor: SYSTEM_ACTOR,
+        action: AuditAction.EXPORT_JOB,
+        resourceType: AuditResourceType.JOB,
+        resourceId: job.id,
+        jobId: bullJobId ?? job.queueJobId ?? job.id,
+        description: `Admin export job failed: dataType=${job.dataType}, requestedBy=${job.userId}, error=${message}`,
+        previousValue: beforeState,
+        newValue: { status: AdminExportStatus.FAILED, errorMessage: message },
+        durationMs: Date.now() - startedAt,
+        success: false,
+        errorMessage: message,
+      });
+
       throw error;
     }
   }

--- a/backend/src/modules/data-export/data-export.processor.ts
+++ b/backend/src/modules/data-export/data-export.processor.ts
@@ -14,6 +14,9 @@ export class DataExportProcessor {
 
   @Process(DATA_EXPORT_JOB_NAME)
   async handle(job: Job<{ requestId: string }>): Promise<void> {
-    await this.dataExportService.processExportJob(job.data.requestId);
+    await this.dataExportService.processExportJob(
+      job.data.requestId,
+      String(job.id),
+    );
   }
 }

--- a/backend/src/modules/data-export/data-export.service.ts
+++ b/backend/src/modules/data-export/data-export.service.ts
@@ -36,6 +36,12 @@ import {
   DATA_EXPORT_PENDING_TTL_MS,
   DATA_EXPORT_QUEUE,
 } from './data-export.constants';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+  SYSTEM_ACTOR,
+} from '../../common/entities/audit-log.entity';
 
 const EXPORT_DIR = path.join(os.tmpdir(), 'nestera-exports');
 const MAX_ACTIVE_EXPORTS_PER_USER = 2;
@@ -58,6 +64,7 @@ export class DataExportService {
     private readonly mailService: MailService,
     @InjectQueue(DATA_EXPORT_QUEUE)
     private readonly dataExportQueue: Queue,
+    private readonly auditLogService: AuditLogService,
   ) {
     fs.mkdirSync(EXPORT_DIR, { recursive: true });
   }
@@ -243,7 +250,7 @@ export class DataExportService {
     };
   }
 
-  async processExportJob(requestId: string): Promise<void> {
+  async processExportJob(requestId: string, bullJobId?: string): Promise<void> {
     const request = await this.exportRepository.findOne({
       where: { id: requestId },
     });
@@ -274,6 +281,16 @@ export class DataExportService {
       });
       throw new NotFoundException('User not found');
     }
+
+    const startedAt = Date.now();
+
+    // Capture before-state for audit diff
+    const beforeState = {
+      requestId: request.id,
+      userId: request.userId,
+      status: request.status,
+      createdAt: request.createdAt?.toISOString(),
+    };
 
     await this.exportRepository.update(request.id, {
       status: ExportStatus.PROCESSING,
@@ -327,6 +344,29 @@ export class DataExportService {
       );
 
       this.logger.log(`Export ${request.id} completed for user ${user.id}`);
+
+      // Audit log – successful user data export job
+      await this.auditLogService.log({
+        actor: SYSTEM_ACTOR,
+        action: AuditAction.EXPORT_JOB,
+        resourceType: AuditResourceType.JOB,
+        resourceId: request.id,
+        jobId: bullJobId ?? request.queueJobId ?? request.id,
+        correlationId: request.id,
+        description: `User data export job completed: userId=${user.id}, transactions=${transactions.length}, goals=${goals.length}, notifications=${notifications.length}.`,
+        previousValue: beforeState,
+        newValue: {
+          status: ExportStatus.READY,
+          completedAt: new Date().toISOString(),
+          recordCounts: {
+            transactions: transactions.length,
+            goals: goals.length,
+            notifications: notifications.length,
+          },
+        },
+        durationMs: Date.now() - startedAt,
+        success: true,
+      });
     } catch (err) {
       const latest = await this.exportRepository.findOne({
         where: { id: request.id },
@@ -335,10 +375,28 @@ export class DataExportService {
         return;
       }
 
+      const errorMessage = err instanceof Error ? err.message : 'Export failed';
       await this.exportRepository.update(request.id, {
         status: ExportStatus.FAILED,
-        errorMessage: err instanceof Error ? err.message : 'Export failed',
+        errorMessage,
       });
+
+      // Audit log – failed user data export job
+      await this.auditLogService.log({
+        actor: SYSTEM_ACTOR,
+        action: AuditAction.EXPORT_JOB,
+        resourceType: AuditResourceType.JOB,
+        resourceId: request.id,
+        jobId: bullJobId ?? request.queueJobId ?? request.id,
+        correlationId: request.id,
+        description: `User data export job failed: userId=${user.id}, error=${errorMessage}.`,
+        previousValue: beforeState,
+        newValue: { status: ExportStatus.FAILED, errorMessage },
+        durationMs: Date.now() - startedAt,
+        success: false,
+        errorMessage,
+      });
+
       throw err;
     }
   }

--- a/backend/src/modules/jobs/jobs.module.ts
+++ b/backend/src/modules/jobs/jobs.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { NotificationProcessor } from './processors/notification.processor';
 import { BlockchainProcessor } from './processors/blockchain.processor';
 import { ReconciliationProcessor } from './processors/reconciliation.processor';
 import { FeeRewardReconciliationService } from './services/fee-reward-reconciliation.service';
+import { ReconciliationRecord } from './entities/reconciliation-record.entity';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([ReconciliationRecord]),
     BullModule.registerQueue(
       { name: 'notifications' },
       { name: 'blockchain' },

--- a/backend/src/modules/jobs/processors/reconciliation.processor.ts
+++ b/backend/src/modules/jobs/processors/reconciliation.processor.ts
@@ -15,10 +15,16 @@ export class ReconciliationProcessor {
   async handleReconciliation(job: Job) {
     this.logger.log(`Processing reconciliation job: ${job.id}`);
     try {
-      const result = await this.reconciliationService.reconcile();
+      const result = await this.reconciliationService.reconcile({
+        jobId: String(job.id),
+        correlationId: (job.data as { correlationId?: string })?.correlationId,
+      });
       this.logger.log(`Job ${job.id} completed: ${JSON.stringify(result)}`);
     } catch (error) {
-      this.logger.error(`Reconciliation job ${job.id} failed: ${error.message}`, error.stack);
+      this.logger.error(
+        `Reconciliation job ${job.id} failed: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
       throw error; // Let Bull handle retries
     }
   }

--- a/backend/src/modules/jobs/services/fee-reward-reconciliation.service.ts
+++ b/backend/src/modules/jobs/services/fee-reward-reconciliation.service.ts
@@ -2,6 +2,19 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ReconciliationRecord } from '../entities/reconciliation-record.entity';
+import { AuditLogService } from '../../../common/services/audit-log.service';
+import {
+  AuditAction,
+  AuditResourceType,
+  SYSTEM_ACTOR,
+} from '../../../common/entities/audit-log.entity';
+
+export interface ReconciliationOptions {
+  /** Bull/BullMQ job ID – forwarded to the audit log for traceability. */
+  jobId?: string;
+  /** Optional correlation ID (e.g. request-id header propagated from the scheduler). */
+  correlationId?: string;
+}
 
 @Injectable()
 export class FeeRewardReconciliationService {
@@ -10,12 +23,20 @@ export class FeeRewardReconciliationService {
   constructor(
     @InjectRepository(ReconciliationRecord)
     private readonly reconciliationRepo: Repository<ReconciliationRecord>,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   // Main reconciliation method: compares expected vs actual fees/rewards
   // and records discrepancies, optionally auto-correcting within safe bounds.
-  async reconcile(): Promise<{ totalChecked: number; discrepancies: number; corrected: number }> {
+  async reconcile(
+    options: ReconciliationOptions = {},
+  ): Promise<{ totalChecked: number; discrepancies: number; corrected: number }> {
     this.logger.log('Starting fee/reward reconciliation...');
+
+    const startedAt = new Date();
+
+    // Snapshot state before reconciliation for before/after diff
+    const beforeSnapshot = await this.buildSnapshot();
 
     // Placeholder: In production, fetch expected and actual data from respective sources.
     // For example:
@@ -24,7 +45,6 @@ export class FeeRewardReconciliationService {
     // - Expected rewards from reward profiles
     // - Actual rewards from reward payout records
 
-    // We simulate a batch of records to process
     const itemsToCheck = await this.fetchItemsToReconcile();
 
     let discrepancies = 0;
@@ -56,44 +76,132 @@ export class FeeRewardReconciliationService {
         expectedAmount: item.expectedAmount,
         actualAmount: item.actualAmount,
         discrepancy: discrepancy,
-        status: absDiscrepancy === 0 ? 'pending' : (absDiscrepancy <= maxAllowedDiscrepancy ? 'corrected' : 'discrepancy_reported'),
-        autoCorrected: absDiscrepancy > 0 && absDiscrepancy <= maxAllowedDiscrepancy,
-        correctedAt: (absDiscrepancy > 0 && absDiscrepancy <= maxAllowedDiscrepancy ? new Date() : null) as unknown as Date,
+        status:
+          absDiscrepancy === 0
+            ? 'pending'
+            : absDiscrepancy <= maxAllowedDiscrepancy
+              ? 'corrected'
+              : 'discrepancy_reported',
+        autoCorrected:
+          absDiscrepancy > 0 && absDiscrepancy <= maxAllowedDiscrepancy,
+        correctedAt: (absDiscrepancy > 0 && absDiscrepancy <= maxAllowedDiscrepancy
+          ? new Date()
+          : null) as unknown as Date,
         notes: `Discrepancy: ${discrepancy}. ${absDiscrepancy > maxAllowedDiscrepancy ? 'Reported for manual review.' : 'Auto-corrected.'}`,
       });
       await this.reconciliationRepo.save(record);
     }
 
-    this.logger.log(`Reconciliation completed: ${itemsToCheck.length} checked, ${discrepancies} discrepancies, ${corrected} auto-corrected.`);
-    return { totalChecked: itemsToCheck.length, discrepancies, corrected };
+    const result = {
+      totalChecked: itemsToCheck.length,
+      discrepancies,
+      corrected,
+    };
+
+    this.logger.log(
+      `Reconciliation completed: ${result.totalChecked} checked, ${result.discrepancies} discrepancies, ${result.corrected} auto-corrected.`,
+    );
+
+    // Build after-snapshot for diff
+    const afterSnapshot = {
+      totalChecked: result.totalChecked,
+      discrepancies: result.discrepancies,
+      corrected: result.corrected,
+      completedAt: new Date().toISOString(),
+    };
+
+    const durationMs = Date.now() - startedAt.getTime();
+    const success = true;
+
+    await this.auditLogService.log({
+      actor: SYSTEM_ACTOR,
+      action: AuditAction.RECONCILE,
+      resourceType: AuditResourceType.JOB,
+      jobId: options.jobId,
+      correlationId: options.correlationId,
+      description: `Fee/reward reconciliation completed: ${result.totalChecked} records checked, ${result.discrepancies} discrepancies found, ${result.corrected} auto-corrected.`,
+      previousValue: beforeSnapshot,
+      newValue: afterSnapshot,
+      durationMs,
+      success,
+    });
+
+    return result;
+  }
+
+  /**
+   * Build a lightweight before-snapshot of reconciliation state.
+   * In production, this could capture aggregate counts from the DB.
+   */
+  private async buildSnapshot(): Promise<Record<string, any>> {
+    const totalRecords = await this.reconciliationRepo.count();
+    return {
+      totalRecordsBeforeRun: totalRecords,
+      snapshotAt: new Date().toISOString(),
+    };
   }
 
   // In production, implement actual data fetching from appropriate sources.
-  private async fetchItemsToReconcile(): Promise<Array<{
-    recordType: string;
-    referenceId: string;
-    expectedAmount: number;
-    actualAmount: number;
-  }>> {
+  private async fetchItemsToReconcile(): Promise<
+    Array<{
+      recordType: string;
+      referenceId: string;
+      expectedAmount: number;
+      actualAmount: number;
+    }>
+  > {
     // Simulated data
     return [
-      { recordType: 'fee', referenceId: 'txn-001', expectedAmount: 0.50, actualAmount: 0.50 },
-      { recordType: 'fee', referenceId: 'txn-002', expectedAmount: 1.00, actualAmount: 1.05 }, // small discrepancy
-      { recordType: 'reward', referenceId: 'user-100', expectedAmount: 100.00, actualAmount: 98.50 }, // larger discrepancy
+      {
+        recordType: 'fee',
+        referenceId: 'txn-001',
+        expectedAmount: 0.5,
+        actualAmount: 0.5,
+      },
+      {
+        recordType: 'fee',
+        referenceId: 'txn-002',
+        expectedAmount: 1.0,
+        actualAmount: 1.05,
+      }, // small discrepancy
+      {
+        recordType: 'reward',
+        referenceId: 'user-100',
+        expectedAmount: 100.0,
+        actualAmount: 98.5,
+      }, // larger discrepancy
     ];
   }
 
-  private async autoCorrect(item: { recordType: string; referenceId: string; expectedAmount: number; actualAmount: number; }, discrepancy: number): Promise<void> {
-    this.logger.warn(`Auto-correcting discrepancy of ${discrepancy} for ${item.recordType} ${item.referenceId}. Expected ${item.expectedAmount}, actual ${item.actualAmount}.`);
+  private async autoCorrect(
+    item: {
+      recordType: string;
+      referenceId: string;
+      expectedAmount: number;
+      actualAmount: number;
+    },
+    discrepancy: number,
+  ): Promise<void> {
+    this.logger.warn(
+      `Auto-correcting discrepancy of ${discrepancy} for ${item.recordType} ${item.referenceId}. Expected ${item.expectedAmount}, actual ${item.actualAmount}.`,
+    );
     // TODO: Implement actual correction logic:
     // - For fees: adjust transaction record or create adjustment entry.
     // - For rewards: adjust reward payout or user balance.
-    // Simulate by logging (in production, perform safe update).
   }
 
-  private async reportDiscrepancy(item: { recordType: string; referenceId: string; expectedAmount: number; actualAmount: number; }, discrepancy: number): Promise<void> {
-    this.logger.error(`Significant discrepancy for ${item.recordType} ${item.referenceId}: expected ${item.expectedAmount}, actual ${item.actualAmount}, diff ${discrepancy}.`);
+  private async reportDiscrepancy(
+    item: {
+      recordType: string;
+      referenceId: string;
+      expectedAmount: number;
+      actualAmount: number;
+    },
+    discrepancy: number,
+  ): Promise<void> {
+    this.logger.error(
+      `Significant discrepancy for ${item.recordType} ${item.referenceId}: expected ${item.expectedAmount}, actual ${item.actualAmount}, diff ${discrepancy}.`,
+    );
     // TODO: Create admin ticket via ticketing system, send notification, etc.
-    // Simulate by logging.
   }
 }


### PR DESCRIPTION
Implement audit logging for automated/background actions with:
- actor type = SYSTEM (SYSTEM_ACTOR constant)
- jobId field on AuditLog (Bull/BullMQ job.id)
- correlationId propagation from job data
- before/after diffs on all instrumented workflows

Workflows covered (4 total):
1. FeeRewardReconciliationService.reconcile()
   - Logs RECONCILE action with before/after snapshot of reconciliation record counts and discrepancy stats
2. AdminExportService.processExportJob()
   - Logs EXPORT_JOB on success (with rowCount) and failure
   - bullJobId threaded through AdminExportProcessor
3. DataExportService.processExportJob()
   - Logs EXPORT_JOB on success (with record counts per type) and failure; bullJobId threaded through DataExportProcessor
4. AdminAuditLogsArchivalService.archiveOldLogs() cron
   - Logs ARCHIVE on success and failure with before/after counts of archived vs remaining logs

Infrastructure changes:
- AuditAction enum: +RECONCILE, +CLEANUP, +ARCHIVE, +EXPORT_JOB
- AuditResourceType enum: +JOB
- AuditLog entity: +jobId column (nullable varchar)
- CreateAuditLogDto: +jobId field
- JobsModule: added TypeOrmModule.forFeature([ReconciliationRecord])
- Migration 1804000000000-AddSystemAuditLoggingSupport: adds job_id column + index, extends action/resource_type enums

Closes #1131